### PR TITLE
docs: add branching workflow rule requiring PRs for main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,6 +426,18 @@ All GitHub Actions workflow files **must** follow these naming and formatting co
 
 - **Always** use `nix profile add`, **never** `nix profile install` (deprecated)
 
+## Branching Workflow
+
+All changes to `main` **must** be made via pull request. Direct pushes to `main` are not allowed (enforced by branch protection rules). The workflow is:
+
+1. Create a feature branch from `main` (e.g., `fix/ci-failures`, `feat/new-tool`)
+2. Make changes, commit, and push the branch
+3. Open a pull request against `main`
+4. Wait for CI to pass
+5. Merge the pull request
+
+Admins may bypass this rule in emergencies, but should prefer PRs whenever possible.
+
 ## Pre-Push Verification
 
 **MANDATORY**: Before pushing any commits to the remote, always run the local CI checks to ensure they pass. At minimum:


### PR DESCRIPTION
## Summary
- Add branching workflow section to CLAUDE.md documenting that all changes to `main` must go through pull requests
- GitHub repository ruleset already created to enforce this (admin bypass enabled)

## Test plan
- [x] Verify ruleset is active on GitHub: https://github.com/ifiokjr/dotfiles/rules/12829365
- [ ] Confirm direct push to main is blocked for non-admins