### PR TITLE
refactor(nix): consolidate homebrew config, add macOS defaults

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -3,12 +3,28 @@
   pkgs,
   self,
   username,
+  homebrew-core,
+  homebrew-cask,
+  homebrew-bundle,
   ...
 }:
 
 {
   nix.enable = false;
   nixpkgs.config.allowUnfree = true;
+
+  nix-homebrew = {
+    enable = true;
+    enableRosetta = true;
+    user = username;
+    autoMigrate = true;
+    taps = {
+      "homebrew/homebrew-core" = homebrew-core;
+      "homebrew/homebrew-cask" = homebrew-cask;
+      "homebrew/homebrew-bundle" = homebrew-bundle;
+    };
+    mutableTaps = false;
+  };
 
   # User configuration
   users.users.${username} = {
@@ -22,6 +38,7 @@
 
   homebrew = {
     enable = true;
+    taps = builtins.attrNames config.nix-homebrew.taps;
     onActivation = {
       autoUpdate = true;
       upgrade = true;
@@ -115,6 +132,7 @@
   environment.systemPackages = with pkgs; [
     # macOS-specific system utilities
     mkalias # For creating app aliases in /Applications
+    tart # macOS VMs on Apple Silicon
 
     # Core system libraries that other packages depend on
     apple-sdk_15
@@ -176,6 +194,151 @@
   # No need to set nixpkgs.hostPlatform here as it's set at the flake level
 
   system.defaults = {
-    dock.autohide = true;
+    dock = {
+      autohide = true;
+      autohide-delay = 0.0;
+      autohide-time-modifier = 0.15;
+      expose-group-apps = true;
+      launchanim = false;
+      mineffect = "scale";
+      minimize-to-application = true;
+      mru-spaces = false;
+      orientation = "bottom";
+      show-recents = false;
+      showhidden = true;
+      static-only = false;
+      tilesize = 48;
+      wvous-tl-corner = 1;
+      wvous-tr-corner = 1;
+      wvous-bl-corner = 1;
+      wvous-br-corner = 1;
+    };
+
+    finder = {
+      _FXShowPosixPathInTitle = true;
+      _FXSortFoldersFirst = true;
+      _FXSortFoldersFirstOnDesktop = true;
+      AppleShowAllExtensions = true;
+      AppleShowAllFiles = true;
+      CreateDesktop = true;
+      FXDefaultSearchScope = "SCcf";
+      FXEnableExtensionChangeWarning = false;
+      FXPreferredViewStyle = "clmv";
+      FXRemoveOldTrashItems = true;
+      QuitMenuItem = true;
+      ShowExternalHardDrivesOnDesktop = true;
+      ShowHardDrivesOnDesktop = false;
+      ShowMountedServersOnDesktop = false;
+      ShowPathbar = true;
+      ShowRemovableMediaOnDesktop = true;
+      ShowStatusBar = true;
+    };
+
+    NSGlobalDomain = {
+      # Keyboard
+      ApplePressAndHoldEnabled = false;
+      InitialKeyRepeat = 15;
+      KeyRepeat = 2;
+      AppleKeyboardUIMode = 3;
+
+      # Appearance
+      AppleInterfaceStyle = "Dark";
+      AppleInterfaceStyleSwitchesAutomatically = false;
+      AppleFontSmoothing = 1;
+      NSUseAnimatedFocusRing = false;
+
+      # Scrolling & navigation
+      "com.apple.swipescrolldirection" = true;
+      AppleEnableSwipeNavigateWithScrolls = true;
+      AppleShowScrollBars = "WhenScrolling";
+      NSScrollAnimationEnabled = true;
+
+      # Trackpad & mouse
+      "com.apple.mouse.tapBehavior" = 1;
+      "com.apple.trackpad.enableSecondaryClick" = true;
+      "com.apple.trackpad.forceClick" = true;
+      "com.apple.trackpad.scaling" = 1.0;
+
+      # Disable all autocorrect
+      NSAutomaticCapitalizationEnabled = false;
+      NSAutomaticDashSubstitutionEnabled = false;
+      NSAutomaticPeriodSubstitutionEnabled = false;
+      NSAutomaticQuoteSubstitutionEnabled = false;
+      NSAutomaticSpellingCorrectionEnabled = false;
+      NSAutomaticInlinePredictionEnabled = false;
+
+      # Expanded dialogs by default
+      NSNavPanelExpandedStateForSaveMode = true;
+      NSNavPanelExpandedStateForSaveMode2 = true;
+      PMPrintingExpandedStateForPrint = true;
+      PMPrintingExpandedStateForPrint2 = true;
+      NSDocumentSaveNewDocumentsToCloud = false;
+
+      # Sound
+      "com.apple.sound.beep.feedback" = 0;
+
+      # Units & time
+      AppleICUForce24HourTime = true;
+      AppleMeasurementUnits = "Centimeters";
+      AppleMetricUnits = 1;
+      AppleTemperatureUnit = "Celsius";
+
+      # Windows
+      AppleWindowTabbingMode = "always";
+      NSWindowShouldDragOnGesture = true;
+      AppleShowAllExtensions = true;
+      _HIHideMenuBar = false;
+    };
+
+    trackpad = {
+      Clicking = true;
+      Dragging = false;
+      TrackpadRightClick = true;
+      TrackpadThreeFingerDrag = true;
+      TrackpadThreeFingerTapGesture = 2;
+      ActuationStrength = 1;
+      FirstClickThreshold = 1;
+      SecondClickThreshold = 1;
+    };
+
+    screencapture = {
+      disable-shadow = true;
+      location = "~/Pictures/Screenshots";
+      type = "png";
+      show-thumbnail = true;
+    };
+
+    controlcenter = {
+      BatteryShowPercentage = true;
+      Bluetooth = true;
+      Sound = true;
+    };
+
+    menuExtraClock = {
+      IsAnalog = false;
+      Show24Hour = true;
+      ShowDate = 1;
+      ShowDayOfMonth = true;
+      ShowDayOfWeek = true;
+      ShowSeconds = true;
+    };
+
+    spaces.spans-displays = false;
+
+    loginwindow = {
+      GuestEnabled = false;
+      DisableConsoleAccess = true;
+    };
+
+    WindowManager = {
+      GloballyEnabled = false;
+      EnableStandardClickToShowDesktop = false;
+      EnableTiledWindowMargins = true;
+      EnableTilingByEdgeDrag = true;
+      EnableTilingOptionAccelerator = true;
+      EnableTopTilingByEdgeDrag = true;
+      StandardHideDesktopIcons = false;
+      StandardHideWidgets = false;
+    };
   };
 }

--- a/Configs/nix/.config/nix/flake.nix
+++ b/Configs/nix/.config/nix/flake.nix
@@ -49,37 +49,15 @@
           modules = [
             ./darwin.nix
             nix-homebrew.darwinModules.nix-homebrew
-            {
-              nix-homebrew = {
-                enable = true;
-                enableRosetta = true;
-                user = username;
-                autoMigrate = true;
-
-                # Optional: Declarative tap management
-                taps = {
-                  "homebrew/homebrew-core" = homebrew-core;
-                  "homebrew/homebrew-cask" = homebrew-cask;
-                  "homebrew/homebrew-bundle" = homebrew-bundle;
-                };
-
-                # Optional: Enable fully-declarative tap management
-                #
-                # With mutableTaps disabled, taps can no longer be added imperatively with `brew tap`.
-                mutableTaps = false;
-              };
-            }
-            # Optional: Align homebrew taps config with nix-homebrew
-            (
-              { config, ... }:
-              {
-                homebrew.taps = builtins.attrNames config.nix-homebrew.taps;
-              }
-            )
-            # Pass the username to darwin.nix
+            # Pass username and homebrew inputs to darwin.nix
             {
               _module.args = {
-                inherit username;
+                inherit
+                  username
+                  homebrew-core
+                  homebrew-cask
+                  homebrew-bundle
+                  ;
               };
             }
             # Integrate home-manager directly with nix-darwin

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -113,6 +113,7 @@ in
       act
       bottom
       cachix
+      cirrus-cli
       coreutils
       curl
       diffutils
@@ -122,6 +123,7 @@ in
       nix-prefetch
       openssh
       openssl
+      orchard
       podman
       protobuf
       scooter


### PR DESCRIPTION
## Summary

- Move nix-homebrew tap configuration and sync overlay from `flake.nix` into `darwin.nix` so all Homebrew config lives in one place
- Pass homebrew inputs (`homebrew-core`, `homebrew-cask`, `homebrew-bundle`) via `_module.args` instead of inline modules, shrinking the modules list from 6 to 4
- Add comprehensive `system.defaults` for macOS (dock, finder, NSGlobalDomain, trackpad, screencapture, controlcenter, menuExtraClock, loginwindow, WindowManager)
- Add `tart` to `environment.systemPackages` for macOS VM support on Apple Silicon
- Add `cirrus-cli` and `orchard` to `home.packages` for CI/VM tooling

## Test plan

- [ ] `dprint check` passes
- [ ] `shellcheck` passes on all scripts
- [ ] `nix flake check --impure --no-build` passes
- [ ] `rebuild` applies successfully via darwin-rebuild
- [ ] Logout/login to verify system.defaults take effect (dock, trackpad, finder settings)