### PR TITLE
fix: gitignore nix.conf to prevent leaking access tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ logs/
 
 # User-specific configuration (should not be in dotfiles)
 **/machine.nix
+**/nix.conf
 
 # Environment files with secrets
 .env


### PR DESCRIPTION
## Summary

- Add `**/nix.conf` to `.gitignore` to prevent accidentally committing files containing access tokens (e.g., `access-tokens = github.com=...`)

## Test plan

- [ ] Verify `nix.conf` does not appear in `git status`