### PR TITLE
fix(ci): remove workarounds for failing setup, add CI integrity rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 📦 ensure lint tools available
-        run: |
-          # If darwin-rebuild failed, tools may not be installed. Install via nix profile as fallback.
-          command -v shellcheck || nix profile add nixpkgs#shellcheck
-          command -v dprint || nix profile add nixpkgs#dprint
-          command -v nu || nix profile add nixpkgs#nushell
-
       - name: 🔍 shellcheck bash scripts
         run: |
           shellcheck setup setup-tuckr-symlink.sh Hooks/nix/post.sh Hooks/nushell/post.sh
@@ -140,11 +133,8 @@ jobs:
 
       - name: ✅ verify setup completed
         run: |
-          # If darwin-rebuild failed, reinstall tools for verification
-          command -v tuckr || nix profile add nixpkgs#tuckr
-          command -v nu || nix profile add nixpkgs#nushell
-          echo "tuckr: $(command -v tuckr)"
-          echo "nushell: $(command -v nu)"
+          command -v tuckr && echo "tuckr: ok"
+          command -v nu && echo "nushell: ok"
           tuckr status
 
   docker-integration:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,12 @@ All GitHub Actions workflow files **must** follow these naming and formatting co
 | 🤖    | AI / automation     |
 | ✅    | verify / validate   |
 
+### CI Integrity Rules
+
+- **Never introduce workarounds for failing `./setup`** in `ci.yml`. If `darwin-rebuild` or `home-manager switch` fails during the setup step, fix the root cause (broken packages, wrong config) instead of adding fallback `nix profile add` steps. Workarounds mask real build failures and defeat the purpose of CI.
+- **All tools used in CI steps must come from the setup script**. The `./setup --skip-nix --no-confirm` step installs everything via `darwin-rebuild` (macOS) or `home-manager switch` (Linux). If a tool is missing after setup, it means the nix configuration is broken and must be fixed.
+- **Packages marked as broken on a platform must be moved to platform-conditional lists**. Use `lib.optionals pkgs.stdenv.isLinux` or `lib.optionals pkgs.stdenv.isDarwin` in `home.nix`, or install via nix-casks in `darwin.nix` for macOS GUI apps.
+
 ## Nix Commands
 
 - **Always** use `nix profile add`, **never** `nix profile install` (deprecated)


### PR DESCRIPTION
## Summary
- Remove fallback `nix profile add` steps from CI that masked darwin-rebuild failures
- Restore proper verify step that checks tools exist without installing them as fallback
- Add "CI Integrity Rules" section to CLAUDE.md forbidding workarounds

## Context
The previous PR added workaround steps that would install tools via `nix profile add` if `darwin-rebuild` failed. This defeated the purpose of CI by masking real configuration bugs (like the broken blender package). The root cause was fixed (blender moved to Linux-only, installed via nix-casks on macOS), so the workarounds are no longer needed and must be removed.

## Test plan
- [ ] All 8 CI checks pass without workaround steps
- [ ] `lint (macos-latest)` finds shellcheck, dprint, nu from darwin-rebuild
- [ ] `setup script (macos-latest)` finds tuckr and nu from darwin-rebuild