### PR TITLE
style(nix): switch menu bar clock to analog and remove seconds

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -280,12 +280,12 @@ in
     };
 
     menuExtraClock = {
-      IsAnalog = false;
+      IsAnalog = true;
       Show24Hour = true;
       ShowDate = 1;
       ShowDayOfMonth = true;
       ShowDayOfWeek = true;
-      ShowSeconds = true;
+      ShowSeconds = false;
     };
 
     spaces.spans-displays = false;


### PR DESCRIPTION
## Summary

- Switch macOS menu bar clock from digital to analog style
- Disable seconds display for a cleaner menu bar

## Test plan

- [ ] `rebuild` — verify nix-darwin applies the new defaults
- [ ] Check menu bar clock shows analog style without seconds