### PR TITLE
feat(nix): add xcodes to darwin system packages

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -39,6 +39,7 @@ in
       # macOS-specific system utilities
       mkalias # For creating app aliases in /Applications
       tart # macOS VMs on Apple Silicon
+      xcodes # Install and manage multiple Xcode versions
 
       # Core system libraries that other packages depend on
       apple-sdk_15


### PR DESCRIPTION
## Summary

- Add `xcodes` to macOS system packages in `darwin.nix` for installing and managing multiple Xcode versions

## Test plan

- [ ] CI passes
- [ ] `rebuild` installs xcodes successfully