### PR TITLE
[codex] hide .app extensions in Spotlight app results

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -138,7 +138,7 @@ in
       mkdir -p /Applications/Nix\ Apps
       find ${env}/Applications -maxdepth 1 -type l -exec readlink '{}' + |
       while IFS= read -r src; do
-        app_name=$(basename "$src")
+        app_name=$(basename "$src" .app)
         echo "copying $src" >&2
         ${pkgs.mkalias}/bin/mkalias "$src" "/Applications/Nix Apps/$app_name"
       done


### PR DESCRIPTION
## Summary
Spotlight was showing app names with the `.app` suffix for applications exposed through `/Applications/Nix Apps`.

## Issue
The app aliases created during nix-darwin activation preserved the source bundle filename verbatim (for example `Ghostty.app`). Those alias names are indexed by Spotlight and surfaced with the extension.

## Root Cause
In the activation script in `darwin.nix`, alias names were derived with:

- `app_name=$(basename "$src")`

Because `$src` points to an app bundle path ending in `.app`, the generated alias filename also ended in `.app`.

## Fix
The alias name derivation now strips the `.app` suffix when present:

- `app_name=$(basename "$src" .app)`

This keeps the alias target unchanged while ensuring the visible alias name and Spotlight result are extensionless.

## Validation
- Parsed config successfully: `nix-instantiate --parse Configs/nix/.config/nix/darwin.nix`
- Verified diff scope is limited to the alias name line in activation script.
