### PR TITLE
fix(setup): pre-create tuckr directories and defer profile cleanup

### DIFF
--- a/setup
+++ b/setup
@@ -535,6 +535,24 @@ deploy_groups() {
             print_info "This may take several minutes..."
             echo ""
 
+            # On Linux, standalone home-manager shares the nix profile with
+            # `nix profile add`. Remove temporary packages now to avoid
+            # "An existing package already provides the following file" conflict.
+            # On macOS, nix-darwin uses /etc/profiles/per-user/ (separate path),
+            # so no conflict — cleanup happens at the end instead.
+            if [[ "$PLATFORM" != "macos" ]]; then
+                if [ "$INSTALLED_TUCKR" = true ]; then
+                    print_info "Removing temporary tuckr to avoid nix profile conflict"
+                    run_nix profile remove --regex '.*tuckr.*' 2>/dev/null || true
+                    INSTALLED_TUCKR=false
+                fi
+                if [ "$INSTALLED_NUSHELL" = true ]; then
+                    print_info "Removing temporary nushell to avoid nix profile conflict"
+                    run_nix profile remove --regex '.*nushell.*' 2>/dev/null || true
+                    INSTALLED_NUSHELL=false
+                fi
+            fi
+
             if tuckr_deploy "$TUCKR" nix set; then
                 print_success "Deployed nix"
             else


### PR DESCRIPTION
## Summary

- Replace hardcoded `mkdir -p ~/.config` and `mkdir -p ~/.local/bin` with a dynamic scan of `Configs/*/` that mirrors every subdirectory under `$HOME`. This eliminates all `No such file or directory (os error 2)` symlink errors from tuckr across multiple groups (nix/packages, helix/cogs, helix/languages, zellij/layouts, nushell/modules, etc.).
- Move temporary tuckr/nushell nix profile removal from before `darwin-rebuild` to the cleanup phase. On macOS with `useUserPackages = true`, nix-darwin uses `/etc/profiles/per-user/` which doesn't conflict with `~/.nix-profile/`. The existing `cleanup()` function already handles the removal.

## Test plan

- [ ] CI `ci-nix` workflow passes on both macOS and Ubuntu
- [ ] No `failed to symlink group` errors in setup output
- [ ] `Removing tuckr from nix profile` appears in cleanup phase (not before nix deployment)