### PR TITLE
fix(nushell): patch deprecated --ignore-errors flag in mise.nu

### DIFF
--- a/Hooks/nushell/post.sh
+++ b/Hooks/nushell/post.sh
@@ -87,6 +87,9 @@ if [ -x "$NU_PATH" ]; then
 		# shellcheck disable=SC2016
 		sed -i '' 's#| update optional true | into cell-path#| each { |r| $r | merge { optional: true } } | into cell-path#' "$VENDOR_AUTOLOAD_DIR/mise.nu" 2>/dev/null ||
 			sed -i 's#| update optional true | into cell-path#| each { |r| $r | merge { optional: true } } | into cell-path#' "$VENDOR_AUTOLOAD_DIR/mise.nu" 2>/dev/null || true
+		# Fix deprecated --ignore-errors flag (renamed to --optional in nushell 0.106.0)
+		sed -i '' 's#--ignore-errors#--optional#g' "$VENDOR_AUTOLOAD_DIR/mise.nu" 2>/dev/null ||
+			sed -i 's#--ignore-errors#--optional#g' "$VENDOR_AUTOLOAD_DIR/mise.nu" 2>/dev/null || true
 		echo -e "${GREEN}✓${NC} Generated mise.nu"
 	else
 		echo -e "${YELLOW}!${NC} mise not found, skipping mise.nu"


### PR DESCRIPTION
## Summary

- Patch the mise-generated `mise.nu` vendor autoload script to replace the deprecated `--ignore-errors` flag with `--optional` (renamed in nushell 0.106.0)
- Follows the same sed-based patching pattern already used for the `update optional true` incompatibility

Fixes the warning on every new shell:
```
Warning: nu::parser::deprecated
  get --ignore-errors was deprecated in 0.106.0 and will be removed in a future release.
  help: This flag has been renamed to `--optional (-o)`
```

## Test plan

- [x] Open a new nushell shell and verify the deprecation warning is gone
- [x] Verify `mise` still activates correctly (`mise doctor`)
- [x] `shellcheck Hooks/nushell/post.sh` passes