### PR TITLE
feat(nix): add bun to home packages

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -35,6 +35,7 @@ in
       awscli2
       bat
       biome
+      bun
       cargo-sweep
       cargo-update
       claude-code


### PR DESCRIPTION
## Summary

- Add `bun` JavaScript runtime to the shared home packages in `home.nix`

## Test plan

- [ ] CI lint passes (nix flake check, formatting)
- [ ] CI test passes on both platforms
- [ ] `bun --version` works after `rebuild`