### PR TITLE
feat(nix): add pulumi-bin and pulumi-esc to home packages

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -68,6 +68,8 @@ in
       nixfmt
       ollama
       opencode
+      pulumi-bin
+      pulumi-esc
       racket-minimal-custom
       rustup
       spec-kit


### PR DESCRIPTION
## Summary

- Add `pulumi-bin` (Pulumi CLI) and `pulumi-esc` (Pulumi ESC for secrets/config management) to shared home packages

## Test plan

- [ ] CI lint passes (nix flake check, formatting)
- [ ] CI test passes on both platforms