### PR TITLE
chore(nix): track flake.lock and update custom packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ Configs/nix/.config/nix/.devenv/
 Configs/nix/.config/nix/.devenv.flake.nix
 **/result
 **/result-*
-**/flake.lock
+# **/flake.lock
 .direnv/
 **/.direnv/
 .nix-defexpr/

--- a/Configs/nix/.config/nix/flake.lock
+++ b/Configs/nix/.config/nix/flake.lock
@@ -1,0 +1,148 @@
+{
+  "nodes": {
+    "darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771520882,
+        "narHash": "sha256-9SeTZ4Pwr730YfT7V8Azb8GFbwk1ZwiQDAwft3qAD+o=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "6a7fdcd5839ec8b135821179eea3b58092171bcf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "ref": "master",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1771851181,
+        "narHash": "sha256-gFgE6mGUftwseV3DUENMb0k0EiHd739lZexPo5O/sdQ=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "9a4b494b1aa1b93d8edf167f46dc8e0c0011280c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nix-casks": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1771891269,
+        "narHash": "sha256-q6WTDy/aUnUR7AZG575+bG106XwKV0dQGQw1lvsDKL8=",
+        "owner": "atahanyorganci",
+        "repo": "nix-casks",
+        "rev": "e33b5c260d8dd6402e7a8105cfafd260ec15b967",
+        "type": "github"
+      },
+      "original": {
+        "owner": "atahanyorganci",
+        "ref": "archive",
+        "repo": "nix-casks",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771482645,
+        "narHash": "sha256-MpAKyXfJRDTgRU33Hja+G+3h9ywLAJJNRq4Pjbb4dQs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "724cf38d99ba81fbb4a347081db93e2e3a9bc2ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1765674936,
+        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "darwin": "darwin",
+        "home-manager": "home-manager",
+        "nix-casks": "nix-casks",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-casks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1767738726,
+        "narHash": "sha256-bHATlMr42JABTJgi4Wc8SJCK8Cv9AnR6HCl3k8eTwEs=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "4db0238d79254c6d14f251808dc5264b8fc81b73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/Configs/nix/.config/nix/packages/codex-cli.nix
+++ b/Configs/nix/.config/nix/packages/codex-cli.nix
@@ -9,7 +9,7 @@ let
   # To update version:
   # 1. Run: update:codex:version
   # 2. Or manually change version, set hashes to lib.fakeSha256, rebuild
-  version = "0.101.0";
+  version = "0.104.0";
   tag = "rust-v${version}";
 
   # Platform mapping: Nix system → release asset suffix
@@ -23,10 +23,10 @@ let
     .${stdenv.hostPlatform.system} or (throw "Unsupported platform: ${stdenv.hostPlatform.system}");
 
   hashes = {
-    "aarch64-apple-darwin" = "sha256-/Ah+kAK+DhcL/qonZZ43eCHhWrl4tKSQde+V21+CB/g=";
-    "x86_64-apple-darwin" = "sha256-UdTjUXx18JMxMr4zZfM7CANtQ9PCBpKzD1zDbdPqw+k=";
-    "aarch64-unknown-linux-musl" = "sha256-9cSxFHMyocxBCLd2x1nue0CdNl5YMKTllmfh+cfm2mA=";
-    "x86_64-unknown-linux-musl" = "sha256-/zY/hZfb8Dg8F2WefJJzW6qZG+irmflnxcw8aLMpJ3w=";
+    "aarch64-apple-darwin" = "sha256-twFR4DigVVJNTQAOgLS30VWGFluEdnSgwyFl0R2sJxE=";
+    "x86_64-apple-darwin" = "sha256-bKIkT4VgC8C7knRKSAezkALnN4xORzLQm6e7DteU1Ow=";
+    "aarch64-unknown-linux-musl" = "sha256-gUyqVfEBbDzOlQ6S4LreBOAOHII5VfbCsCCIPoYtGqY=";
+    "x86_64-unknown-linux-musl" = "sha256-4QloDXgyPo6Od7GyI6JXdv7qbgQOsG9QyKQ5D1k8spg=";
   };
 in
 stdenv.mkDerivation {

--- a/Configs/nix/.config/nix/packages/google-chrome.nix
+++ b/Configs/nix/.config/nix/packages/google-chrome.nix
@@ -46,16 +46,16 @@ let
   sources = {
     "x86_64-darwin" = {
       url = "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg";
-      hash = "sha256-VTF6SG+fon+0CQ3xS4qX5AOFFeP3Qz47ZPIHuBkJcUU=";
+      hash = "sha256-tEZQk64nIU9cgvKwOwBIn4pLv0mTT9vSgmqLEYqCyAg=";
     };
     "aarch64-darwin" = {
       url = "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg";
       # Apple Silicon uses the same universal DMG payload as x86_64 on macOS.
-      hash = "sha256-VTF6SG+fon+0CQ3xS4qX5AOFFeP3Qz47ZPIHuBkJcUU=";
+      hash = "sha256-tEZQk64nIU9cgvKwOwBIn4pLv0mTT9vSgmqLEYqCyAg=";
     };
     "x86_64-linux" = {
       url = "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb";
-      hash = "sha256-VNvx/3l3gzj8HjeeK3v/Hj05E9t2PvsiP8pnIOq1AEA=";
+      hash = "sha256-lGMopGtpLp3g0PVIfRIACNP6yRarzQDIsuctNbiqCCo=";
     };
   };
 

--- a/Configs/nix/.config/nix/packages/nordvpn.nix
+++ b/Configs/nix/.config/nix/packages/nordvpn.nix
@@ -11,7 +11,7 @@ let
   # 3. Set hash to lib.fakeHash
   # 4. Run rebuild - Nix will show the correct hash in the error
   # 5. Copy the correct hash here
-  version = "9.13.0";
+  version = "9.14.0";
 in
 stdenv.mkDerivation {
   pname = "nordvpn";
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://downloads.nordcdn.com/apps/macos/generic/NordVPN-OpenVPN/${version}/NordVPN.pkg";
-    hash = "sha256-vpu+XMqx1kzxMXyqQkLF2Br6t8HMY+q8O4PiUgF7AwY=";
+    hash = "sha256-GCR6eGvQdLLn9bcNtOEDPLjrbA40syBzeXa05zLIETU=";
   };
 
   dontUnpack = true;

--- a/Configs/nix/.config/nix/packages/pnpm-standalone.nix
+++ b/Configs/nix/.config/nix/packages/pnpm-standalone.nix
@@ -11,7 +11,7 @@ let
   # 2. Set hash to lib.fakeSha256
   # 3. Run rebuild - Nix will show the correct hash in the error
   # 4. Copy the correct hash here
-  version = "10.30.0";
+  version = "10.30.2";
 
   # Platform and architecture mapping
   platform = if stdenv.isDarwin then "macos" else "linux";
@@ -20,10 +20,10 @@ let
   # SHA256 hashes for different platforms
   # Using fakeSha256 initially - Nix will provide correct hash on first build
   hashes = {
-    "macos-arm64" = "sha256-/Riad2sI2RVAzueeW0sCT8TH1a7q9ORWHUz5JuDEvmk=";
-    "macos-x64" = "sha256-AvGkXG1bftmF63BlaYHrK7TkLi4pu26CBX0PGU3XdKA=";
-    "linux-arm64" = "sha256-YAKeVl2AAd5xxPIGSv0qIMuF40byXpgDAOnK0CEnenE=";
-    "linux-x64" = "sha256-eNg6oAncfo0Y+vXqh+jK/tlgEkXyN1fwDDWCKE9U95M=";
+    "macos-arm64" = "sha256-lveWjIJVm6fs0nkXFJH9UF1Xo5+H0jzQ/j0+B4G64xE=";
+    "macos-x64" = "sha256-G4SeZQSznCtaiCgIMLpZRY6JJlAgLdFF2DVTlNTflTI=";
+    "linux-arm64" = "sha256-vCX8zmwF6lUdeNK3LIW4Bo31afk/3BX39qzAAogCTv8=";
+    "linux-x64" = "sha256-jglTYI+qHfMhh+eo/3PiwUiyi1LDhg6b3gwT0I2ji8k=";
   };
 
   platformKey = "${platform}-${arch}";

--- a/Configs/nix/.config/nix/packages/racket-minimal.nix
+++ b/Configs/nix/.config/nix/packages/racket-minimal.nix
@@ -15,16 +15,16 @@
 # This package uses the official pre-built Racket minimal binaries instead.
 
 let
-  version = "9.0";
+  version = "9.1";
 
   arch = if stdenv.isAarch64 then "aarch64" else "x86_64";
   os = if stdenv.isDarwin then "macosx" else "linux-buster";
 
   hashes = {
-    "aarch64-macosx" = "sha256-Iyk7oMMpLJP6NBuf7uX4kwVSBNOZI4gOYGyC0VCej/I=";
-    "x86_64-macosx" = "sha256-BRn/s02MGUqaIysM0SyeGbhznz+DZXsF3sUr9O/u2Sc=";
-    "aarch64-linux-buster" = "sha256-HwPIo5KUV00ysqOqIoy5+QPURxy0+kG+MuscRgTQnHM=";
-    "x86_64-linux-buster" = "sha256-FiYhLe7S5SOD0Qz6fmd1/Ty4QsCUxYQdzjV+i+moSek=";
+    "aarch64-macosx" = "sha256-5TtdBh+FXnRUi32LW+pr7GidVNBe2H5IXlNIFsmwlrw=";
+    "x86_64-macosx" = "sha256-ih+FNqA2q0yoXrVn6vTs4emOjNQapRvs9L6de7Gyn28=";
+    "aarch64-linux-buster" = "sha256-q9KH9RK2Y+2YSGCs+GElO3WVARAdxyhjKAnL/+L6WGE=";
+    "x86_64-linux-buster" = "sha256-vVY+O5ZNs0G8QYdYia3aqNh1UuS/YrTlDHVuWm8aPVA=";
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
## Summary

- Stop gitignoring `flake.lock` so flake inputs are pinned and reproducible across machines
- Update custom package versions and hashes for all platforms:
  - codex-cli: 0.101.0 → 0.104.0
  - pnpm-standalone: 10.30.0 → 10.30.2
  - racket-minimal: 9.0 → 9.1
  - nordvpn: 9.13.0 → 9.14.0
  - google-chrome: refresh rolling hashes (fixes CI setup failure)

## Test plan

- [ ] CI lint passes
- [ ] CI test passes on both platforms
- [ ] `ci-nix` setup script passes on ubuntu (Chrome hash fix)
- [ ] `ci-nix` setup script passes on macOS