### PR TITLE
fix(nix): refresh linux chrome package hash

### DIFF
--- a/Configs/nix/.config/nix/packages/google-chrome.nix
+++ b/Configs/nix/.config/nix/packages/google-chrome.nix
@@ -46,12 +46,12 @@ let
   sources = {
     "x86_64-darwin" = {
       url = "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg";
-      hash = "sha256-VTF6SG+fon+0CQ3xS4qX5AOFFeP3Qz47ZPIHuBkJcUU=";
+      hash = "sha256-tEZQk64nIU9cgvKwOwBIn4pLv0mTT9vSgmqLEYqCyAg=";
     };
     "aarch64-darwin" = {
       url = "https://dl.google.com/chrome/mac/universal/stable/GGRO/googlechrome.dmg";
       # Apple Silicon uses the same universal DMG payload as x86_64 on macOS.
-      hash = "sha256-VTF6SG+fon+0CQ3xS4qX5AOFFeP3Qz47ZPIHuBkJcUU=";
+      hash = "sha256-tEZQk64nIU9cgvKwOwBIn4pLv0mTT9vSgmqLEYqCyAg=";
     };
     "x86_64-linux" = {
       url = "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb";


### PR DESCRIPTION
## Summary
- update the pinned Linux hash for google-chrome-stable_current_amd64.deb
- align the hash with the value reported by the failing GitHub Actions job

## Why
The `setup script (ubuntu-latest)` job in run 22355085031 failed with a fixed-output hash mismatch for Chrome.

## Validation
- `nix store prefetch-file --json https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb`
- confirmed returned hash: `sha256-lGMopGtpLp3g0PVIfRIACNP6yRarzQDIsuctNbiqCCo=`
