### PR TITLE
fix(ci): resolve rebuild flake path in workflow checkouts

### DIFF
--- a/Configs/scripts/.local/bin/nu_modules/nix_config.nu
+++ b/Configs/scripts/.local/bin/nu_modules/nix_config.nu
@@ -15,7 +15,17 @@ export def flake-dir [] {
     let flake_nix = $"($link_dir)/flake.nix"
     if ($flake_nix | path exists) { 
     # path expand resolves the symlink; dirname gives the flake root
-    ($flake_nix | path expand | path dirname) } else { $link_dir }
+    ($flake_nix | path expand | path dirname) } else {
+        # CI/workflow checkouts may run without ~/.config/nix symlinks deployed.
+        # In that case, fall back to the flake path inside the checked out repo.
+        let repo_root = try {
+            ^git rev-parse --show-toplevel | str trim
+        } catch { "" }
+        if ($repo_root | is-not-empty) {
+            let repo_flake = $"($repo_root)/Configs/nix/.config/nix/flake.nix"
+            if ($repo_flake | path exists) { ($repo_flake | path expand | path dirname) } else { $link_dir }
+        } else { $link_dir }
+    }
 }
 # Path to machine.nix
 export def machine-config-path [] { $"(config-dir)/machine.nix" }

--- a/Configs/scripts/.local/bin/test_scripts
+++ b/Configs/scripts/.local/bin/test_scripts
@@ -84,6 +84,19 @@ def main [] {
         }
     }) { $passed += 1 } else { $failed += 1 }
 
+    if (run_test "nix_config: flake-dir fallback to repo checkout" { ||
+        let temp_home = "/tmp/test-flake-dir-home"
+        if ($temp_home | path exists) { rm -rf $temp_home }
+        mkdir $temp_home
+
+        let resolved = (with-env { HOME: $temp_home } { nix_config flake-dir })
+        if not ($resolved | str ends-with "Configs/nix/.config/nix") {
+            error make { msg: $"unexpected fallback flake-dir: ($resolved)" }
+        }
+
+        rm -rf $temp_home
+    }) { $passed += 1 } else { $failed += 1 }
+
     print ""
 
     # ── Script Parse Tests (--help) ───────────────────────────────


### PR DESCRIPTION
## Problem
Workflow run https://github.com/ifiokjr/dotfiles/actions/runs/22517376785/job/65237095459 failed in `🔄 update flake lock` with:

- `path '/home/runner/.config/nix' does not contain a 'flake.nix'`
- `error: could not find a flake.nix file`

## Root cause
`rebuild` resolves flake location via `~/.config/nix`, but this workflow runs from a plain repo checkout without deployed symlinks in `~/.config/nix`.

## Fix
- update `nix_config flake-dir` to fall back to `<repo>/Configs/nix/.config/nix` when `~/.config/nix/flake.nix` is missing
- add a regression test in `test_scripts` for the checkout fallback behavior

## Verification
- `dprint check --config Configs/dprint/dprint.json`
- `nu Configs/scripts/.local/bin/test_scripts`
- `shellcheck setup setup-tuckr-symlink.sh Hooks/*/post.sh tests/docker-integration-test.sh`
