### PR TITLE
feat(nix): add codexbar and cargo-interactive-update

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -98,6 +98,7 @@ in
       ])
       ++ [
         # Custom packages from ifiokjr/nixpkgs (apps not available in nix-casks)
+        extra.codexbar
         extra.google-chrome
         extra.google-drive
         extra.gpg-suite

--- a/Configs/nix/.config/nix/flake.lock
+++ b/Configs/nix/.config/nix/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772060133,
-        "narHash": "sha256-VuyRptb8v1lVGMlLp4/1vRX3Efwec0CN0S6mKmDPzLg=",
+        "lastModified": 1772218752,
+        "narHash": "sha256-G8nArvOTZXU8DRvrzAdz3Elcj6kA/vMtvY9mrGLATtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ce9b6e52500a0ea0ec48f0bbf6d7a3e431d9dfa4",
+        "rev": "f3a30376bb9eb2f6f61816be7d6ed954b6d2a3b9",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772096349,
-        "narHash": "sha256-xOFOV9I5G6wMZYKVXzq44Sq5myd/IiKiYdT7s2cDPVI=",
+        "lastModified": 1772267738,
+        "narHash": "sha256-4FEgQwDUHfdnzOKeuMN5Xt3OQVXSQsybPxYI5BgIuzI=",
         "owner": "ifiokjr",
         "repo": "nixpkgs",
-        "rev": "fb181fc49063e1c8095b4347a56915a46e01d690",
+        "rev": "19df72cfbcc09fd3542de0b12c7d6857a4708266",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1772064071,
-        "narHash": "sha256-YvRsSfJPRNNpVJRsut4A20O7B0K31QcpyYCdGs+c6p0=",
+        "lastModified": 1772236872,
+        "narHash": "sha256-lP5FErCYEJyD+tHfk11RDjXg1UqHNOAHAUjn6T7dAkA=",
         "owner": "atahanyorganci",
         "repo": "nix-casks",
-        "rev": "8ee6b922e5561bbe4f0d9de0386effdaa2e30252",
+        "rev": "05c3bcda7bf4f9295a1f37db81f22c2140703a8c",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771923393,
-        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
+        "lastModified": 1772173633,
+        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
         "type": "github"
       },
       "original": {

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -150,6 +150,7 @@ in
       zlib
 
       # Custom packages from ifiokjr/nixpkgs
+      extra.cargo-interactive-update
       extra.pnpm-standalone
 
       # Fonts


### PR DESCRIPTION
## Summary
- add `extra.codexbar` as a GUI app in the non-lite macOS GUI app block
- add `extra.cargo-interactive-update` from `ifiokjr/nixpkgs` to shared home-manager packages
- include updated `flake.lock`

## Verification
- `dprint check --config Configs/dprint/dprint.json`
- `NIX_USER_CONFIG_DIR="$HOME/.config/nix" nix flake check ./Configs/nix/.config/nix --impure --no-build`
