### PR TITLE
fix(setup): make pnpm sync hook resilient in CI

### DIFF
--- a/Configs/scripts/.local/bin/pnpm:global:sync
+++ b/Configs/scripts/.local/bin/pnpm:global:sync
@@ -54,13 +54,25 @@ fail() {
 # Home Manager activation hooks may run in a non-login shell where PATH does
 # not include nix profile bins yet. Ensure common nix profile locations exist
 # on PATH before checking for pnpm.
-for _p in "$HOME/.nix-profile/bin" \
-  "/etc/profiles/per-user/${USER}/bin" \
-  "/run/current-system/sw/bin" \
-  "/nix/var/nix/profiles/default/bin"; do
+user_name="${USER:-}"
+if [ -z "$user_name" ]; then
+  user_name="$(id -un 2>/dev/null || true)"
+fi
+
+profile_paths=(
+  "$HOME/.nix-profile/bin"
+  "/run/current-system/sw/bin"
+  "/nix/var/nix/profiles/default/bin"
+)
+
+if [ -n "$user_name" ]; then
+  profile_paths+=("/etc/profiles/per-user/${user_name}/bin")
+fi
+
+for _p in "${profile_paths[@]}"; do
   [ -d "$_p" ] && case ":$PATH:" in *":$_p:"*) ;; *) export PATH="$_p:$PATH" ;; esac
 done
-unset _p
+unset _p user_name profile_paths
 
 if ! command -v pnpm >/dev/null 2>&1; then
   fail "pnpm is not installed; skipping pnpm global sync"

--- a/Hooks/pnpm/post.sh
+++ b/Hooks/pnpm/post.sh
@@ -14,7 +14,9 @@ if [ ! -x "$SYNC_SCRIPT" ]; then
 fi
 
 if [ -x "$SYNC_SCRIPT" ]; then
-	"$SYNC_SCRIPT"
+	# Setup may run before nix rebuild finishes in CI containers.
+	# Treat pnpm sync as best-effort during hook execution.
+	"$SYNC_SCRIPT" --no-fail
 else
 	echo "pnpm:global:sync not found at ~/.local/bin; skipping"
 fi


### PR DESCRIPTION
## Problem
Latest `ci-nix` run failed after adding the `pnpm` post-hook, including:
- setup script jobs (`ubuntu-latest`, `macos-latest`) failing when pnpm is unavailable during bootstrap
- docker integration failing with `USER: unbound variable` from `pnpm:global:sync`

Failing run:
- https://github.com/ifiokjr/dotfiles/actions/runs/22657774636/job/65671131142

## Changes
- `Configs/scripts/.local/bin/pnpm:global:sync`
  - avoid `set -u` crash when `USER` is unset by deriving a safe fallback username
  - build PATH bootstrap list dynamically and only include per-user profile path when username is known
- `Hooks/pnpm/post.sh`
  - run sync in best-effort mode with `--no-fail` so setup does not fail hard when pnpm is temporarily unavailable during bootstrap

## Verification
- `env -i HOME="$HOME" PATH="/usr/bin:/bin" bash -lc 'unset USER; Configs/scripts/.local/bin/pnpm:global:sync --quiet --no-fail; echo rc:$?'`
- `shellcheck Hooks/pnpm/post.sh Configs/scripts/.local/bin/pnpm:global:sync`
- `dprint check --config Configs/dprint/dprint.json`