### PR TITLE
feat: add ungoogled-chromium for linux and make google-chrome cross-platform

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -169,6 +169,9 @@ in
       nerd-fonts.sauce-code-pro
       nerd-fonts.symbols-only
     ]
+    ++ lib.optionals (!lite) [
+      google-chrome
+    ]
     ++ lib.optionals pkgs.stdenv.isDarwin (
       [
         # macOS-only packages
@@ -190,7 +193,7 @@ in
       lib.optionals (!lite) [
         blender # broken on macOS in nixpkgs; macOS uses nix-casks
         ghostty
-        google-chrome
+        ungoogled-chromium
       ]
     );
 


### PR DESCRIPTION
## Changes

- Add `ungoogled-chromium` to the Linux-only `!lite` package list
- Move `google-chrome` from Linux-only to a cross-platform `!lite` block so it is installed on both Linux and macOS

Both packages are excluded when `--lite` is active.