### PR TITLE
fix(ci): use nix run for nushell in update-nix workflow

### DIFF
--- a/.github/workflows/update-nix.yml
+++ b/.github/workflows/update-nix.yml
@@ -26,11 +26,8 @@ jobs:
       - name: 🔧 set up nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - name: 📦 install nushell
-        run: nix profile add nixpkgs#nushell
-
       - name: 🔄 update flake lock
-        run: nu Configs/scripts/.local/bin/rebuild --update --skip-check
+        run: nix run nixpkgs#nushell -- Configs/scripts/.local/bin/rebuild --update --skip-check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The `update-nix` workflow was failing because nushell was installed into the nix profile via `nix profile add nixpkgs#nushell`, and then `rebuild --update` triggered `home-manager switch` which also includes nushell in `home.packages`. Both the standalone profile entry and `home-manager-path` provided `/bin/nu`, causing a conflict:

```
error: An existing package already provides the following file:
  /nix/store/.../home-manager-path/bin/nu
This is the conflicting file from the new package:
  /nix/store/.../nushell-0.111.0/bin/nu
```

**Fix:** Replace `nix profile add nixpkgs#nushell` + `nu ...` with `nix run nixpkgs#nushell -- ...` so nushell is used transiently without being added to the profile, avoiding the collision.

Fixes: https://github.com/ifiokjr/dotfiles/actions/runs/22705148408/job/65830503021

## Test plan

- [x] Verified the diff is minimal and correct
- [x] The `ci.yml` nushell installs are unaffected (those jobs don't run `rebuild`/`home-manager switch`)