### PR TITLE
fix: suppress boehm-gc "Exclusion ranges overlap" warnings

### DIFF
--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -84,6 +84,10 @@ $env.CARAPACE_BRIDGES = "zsh,fish,bash,inshellisense"
 # Force epoch 0 for deterministic/reproducible Nix builds
 $env.SOURCE_DATE_EPOCH = "0"
 $env.DIRENV_LOG_FORMAT = ""
+# Suppress boehm-gc "Exclusion ranges overlap" warnings on macOS.
+# The boehm-gc library (linked into nix) prints these harmless warnings
+# to stderr during memory region setup, polluting devenv/direnv output.
+$env.GC_LOG_FILE = "/dev/null"
 # ---------------------------------------------------------------------------
 # PATH (single consolidation point)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The boehm-gc 8.2.8 library (linked into nix libraries used by devenv) prints "Exclusion ranges overlap" warnings to stderr on macOS during memory region setup. These are harmless but pollute devenv/direnv output on every directory change.

Fix: set `GC_LOG_FILE=/dev/null` globally in nushell env to redirect boehm-gc diagnostic output.