### PR TITLE
fix(nushell): avoid prompt corruption when direnv/devenv fails

### DIFF
--- a/Configs/nushell/.config/nushell/config.nu
+++ b/Configs/nushell/.config/nushell/config.nu
@@ -25,7 +25,21 @@ $env.config = {
                 # it catches: directory changes, `direnv allow`, and file edits.
                 # Based on: https://direnv.net/docs/hook.html
                 if (which direnv | is-empty) { return }
-                let direnv_out = (direnv export json | from json | default {})
+                # Capture stdout/stderr so direnv/devenv build errors don't corrupt prompt rendering.
+                # (e.g. "↑↓ navigatedirenv: failed to build the devenv environment")
+                let result = (^direnv export json | complete)
+                if ($result.exit_code != 0) {
+                    if ($env | get -o DOTFILES_DEBUG | is-not-empty) {
+                        let err = ($result.stderr | str trim)
+                        if ($err | is-not-empty) { print $"(ansi yellow)direnv skipped:(ansi reset) ($err)" }
+                    }
+                    return
+                }
+                let stdout = ($result.stdout | str trim)
+                if ($stdout | is-empty) { return }
+                let direnv_out = (try {
+                    $stdout | from json
+                } catch { {} })
                 if ($direnv_out | is-empty) { return }
                 let env_to_load = if ($direnv_out | get -o PATH | is-not-empty) {
                     let path_as_list = ($direnv_out | get PATH | split row (char esep))


### PR DESCRIPTION
## Summary
- harden the Nushell pre_prompt direnv hook in Configs/nushell/.config/nushell/config.nu
- capture direnv export json output via complete and guard on non-zero exit
- avoid leaking direnv/devenv stderr into prompt rendering
- keep optional debug output gated behind DOTFILES_DEBUG

## Verification
- dprint check --config Configs/dprint/dprint.json
- nu -n -c 'source Configs/nushell/.config/nushell/config.nu'
