### PR TITLE
fix(nix): avoid darwin ast-grep check failure

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -8,6 +8,15 @@
 
 let
   extra = ifiokjr-nixpkgs.packages.${pkgs.stdenv.system};
+  # Work around intermittent ast-grep check failures on Darwin
+  # (`Illegal byte sequence (os error 92)`) during source builds.
+  astGrepPackage =
+    if pkgs.stdenv.isDarwin then
+      pkgs.ast-grep.overrideAttrs (_: {
+        doCheck = false;
+      })
+    else
+      pkgs.ast-grep;
 in
 {
   # Home Manager configuration for nix-darwin integration
@@ -27,7 +36,7 @@ in
     with pkgs;
     [
       # Development Tools
-      ast-grep
+      astGrepPackage
       atuin
       awscli2
       bat

--- a/Configs/pnpm/.config/pnpm-global/pnpm-workspace.yaml
+++ b/Configs/pnpm/.config/pnpm-global/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 onlyBuiltDependencies:
-  - '@googleworkspace/cli'
+  - "@googleworkspace/cli"


### PR DESCRIPTION
## Summary
- disable `ast-grep` checks on Darwin in `home.nix` to avoid intermittent `Illegal byte sequence (os error 92)` test failures during source builds
- format `Configs/pnpm/.config/pnpm-global/pnpm-workspace.yaml` to satisfy dprint

## Verification
- `dprint check --config Configs/dprint/dprint.json`
- `NIX_USER_CONFIG_DIR=$PWD/Configs/nix/.config/nix nix flake check ./Configs/nix/.config/nix --impure --no-build`
- built patched Darwin ast-grep derivation successfully via `nix build` expression on `home.packages`