### PR TITLE
fix(ci): fix dprint formatting and Homebrew tap conflict on macOS runner

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -116,13 +116,19 @@ jobs:
       - name: 📥 checkout repository
         uses: actions/checkout@v4
 
-      - name: 🧹 free disk space (macos)
+      - name: 🧹 free disk space & remove pre-installed Homebrew (macos)
         run: |
           # Remove Xcode to free ~12GB (nix provides its own build tools)
           sudo rm -rf /Applications/Xcode_*.app
           # Remove simulators
           xcrun simctl delete all 2>/dev/null || true
           sudo rm -rf ~/Library/Developer/CoreSimulator
+          # Remove pre-installed Homebrew so nix-homebrew can manage it
+          # declaratively without "existing /opt/homebrew/Library/Taps" conflicts.
+          sudo rm -rf /opt/homebrew/Library/Taps
+          sudo rm -rf /opt/homebrew/Library/Homebrew
+          sudo rm -rf /opt/homebrew/Library/Contributions
+          sudo rm -rf /opt/homebrew/.git
           df -h /
 
       - name: 🔧 install nix

--- a/Configs/nix/.config/nix/flake.nix
+++ b/Configs/nix/.config/nix/flake.nix
@@ -44,11 +44,13 @@
       # Work around intermittent ast-grep check failures on Darwin
       # (`Illegal byte sequence (os error 92)`) during source builds.
       # Applied as an overlay so every consumer (including serpl) benefits.
-      astGrepOverlay = final: prev: prev.lib.optionalAttrs prev.stdenv.isDarwin {
-        ast-grep = prev.ast-grep.overrideAttrs (_: {
-          doCheck = false;
-        });
-      };
+      astGrepOverlay =
+        final: prev:
+        prev.lib.optionalAttrs prev.stdenv.isDarwin {
+          ast-grep = prev.ast-grep.overrideAttrs (_: {
+            doCheck = false;
+          });
+        };
 
       mkDarwinConfig =
         {

--- a/Configs/pi/.pi/agent/keybindings.json
+++ b/Configs/pi/.pi/agent/keybindings.json
@@ -1,3 +1,3 @@
 {
-  "deleteToLineStart": []
+	"deleteToLineStart": []
 }

--- a/Configs/pi/.pi/agent/settings.json
+++ b/Configs/pi/.pi/agent/settings.json
@@ -1,9 +1,9 @@
 {
-  "lastChangelogVersion": "0.57.1",
-  "defaultProvider": "anthropic",
-  "defaultModel": "claude-opus-4-6",
-  "defaultThinkingLevel": "xhigh",
-  "packages": [
-    "npm:@ifi/oh-pi"
-  ]
+	"lastChangelogVersion": "0.57.1",
+	"defaultProvider": "anthropic",
+	"defaultModel": "claude-opus-4-6",
+	"defaultThinkingLevel": "xhigh",
+	"packages": [
+		"npm:@ifi/oh-pi"
+	]
 }


### PR DESCRIPTION
Fixes both CI failures on main:

**`ci` workflow (lint job)**
- Pi JSON files (`settings.json`, `keybindings.json`) used 2-space indent instead of tabs (dprint convention)
- `flake.nix` ast-grep overlay was on a single line instead of nixfmt multi-line style

**`ci-nix` workflow (macOS setup job)**
- `nix-homebrew` during `darwin-rebuild` fails with `Error: An existing /opt/homebrew/Library/Taps is in the way` because the macOS runner has Homebrew pre-installed
- Added removal of `/opt/homebrew/Library/{Taps,Homebrew,Contributions}` and `.git` before nix install so `nix-homebrew` can manage Homebrew declaratively