### PR TITLE
fix(ci): fully remove pre-installed Homebrew on macOS runner

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -123,12 +123,10 @@ jobs:
           # Remove simulators
           xcrun simctl delete all 2>/dev/null || true
           sudo rm -rf ~/Library/Developer/CoreSimulator
-          # Remove pre-installed Homebrew so nix-homebrew can manage it
-          # declaratively without "existing /opt/homebrew/Library/Taps" conflicts.
-          sudo rm -rf /opt/homebrew/Library/Taps
-          sudo rm -rf /opt/homebrew/Library/Homebrew
-          sudo rm -rf /opt/homebrew/Library/Contributions
-          sudo rm -rf /opt/homebrew/.git
+          # Completely remove pre-installed Homebrew so nix-homebrew can
+          # install and manage it declaratively from scratch.
+          sudo rm -rf /opt/homebrew/*
+          sudo rm -rf /opt/homebrew/.??*
           df -h /
 
       - name: 🔧 install nix


### PR DESCRIPTION
Previous fix only removed `Library/Taps`, `Library/Homebrew`, `Library/Contributions`, and `.git` but the brew binary at `/opt/homebrew/bin/brew` was still present, causing nix-homebrew to fail with:

```
Error: An existing /opt/homebrew/bin/brew is in the way
```

This removes all contents of `/opt/homebrew/` so nix-homebrew can install Homebrew fresh and manage it declaratively.