### PR TITLE
fix(ci): make magic-nix-cache-action non-fatal in ci-nix

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: 🔧 set up nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+        continue-on-error: true
 
       - name: 🧪 run setup script
         run: ./setup --skip-nix --no-confirm --lite
@@ -136,6 +137,7 @@ jobs:
 
       - name: 🔧 set up nix cache
         uses: DeterminateSystems/magic-nix-cache-action@main
+        continue-on-error: true
 
       - name: 🧪 run setup script
         run: ./setup --skip-nix --no-confirm --lite


### PR DESCRIPTION
The `magic-nix-cache-action` consistently fails on macOS runners with `unexpected end-of-file` during `nix-store --import` from a corrupt cache entry. This is an upstream issue with DeterminateSystems.

Adds `continue-on-error: true` to both cache steps (Ubuntu + macOS) so cache failures degrade gracefully to uncached builds instead of blocking CI.