### PR TITLE
fix(pnpm,nushell): remove hardcoded /Users/ifiokjr paths

### DIFF
--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -8,7 +8,7 @@ $env._SHELL_START = (date now)
 # nix-darwin's set-environment has not run), detect and set them manually.
 if not ($env | get -o NIX_PROFILES | is-not-empty) {
     # Replicate nix-darwin's set-environment script
-    let user = ($env | get -o USER | default "ifiokjr")
+    let user = ($env | get -o USER | default (whoami))
     # Nix profiles (matches nix-darwin set-environment)
     $env.NIX_PROFILES = $"/nix/var/nix/profiles/default /run/current-system/sw /etc/profiles/per-user/($user) ($env.HOME)/.nix-profile"
     $env.NIX_USER_PROFILE_DIR = $"/nix/var/nix/profiles/per-user/($user)"

--- a/Configs/pnpm/.config/pnpm-global/package.json
+++ b/Configs/pnpm/.config/pnpm-global/package.json
@@ -18,37 +18,5 @@
 		"tailwindcss-language-server": "^0.0.1",
 		"typescript-language-server": "^5.1.3",
 		"vscode-langservers-extracted": "^4.10.0"
-	},
-	"dependenciesMeta": {
-		"@mariozechner/pi-coding-agent": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"@anthropic-ai/claude-code": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"@devcontainers/cli": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"@google/gemini-cli": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"@openai/codex": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"eslint": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"firebase-tools": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"opencode-ai": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"npm": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		},
-		"@googleworkspace/cli": {
-			"node": "/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node"
-		}
 	}
 }

--- a/Configs/pnpm/.config/pnpm-global/pnpm-lock.yaml
+++ b/Configs/pnpm/.config/pnpm-global/pnpm-lock.yaml
@@ -62,27 +62,6 @@ importers:
       vscode-langservers-extracted:
         specifier: ^4.10.0
         version: 4.10.0
-    dependenciesMeta:
-      '@anthropic-ai/claude-code':
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      '@devcontainers/cli':
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      '@google/gemini-cli':
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      '@googleworkspace/cli':
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      '@mariozechner/pi-coding-agent':
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      '@openai/codex':
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      eslint:
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      firebase-tools:
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      npm:
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
-      opencode-ai:
-        node: /Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node
 
 packages:
 


### PR DESCRIPTION
Three places had the local username baked in, breaking portability across machines:

- **`package.json` `dependenciesMeta`** — removed entirely. It specified `/Users/ifiokjr/Library/pnpm/nodejs/24.14.0/bin/node` as the Node binary for each global package. Without it, pnpm falls back to whatever `node` is in PATH — the correct portable behavior.
- **`pnpm-lock.yaml`** — regenerated without the `dependenciesMeta` entries.
- **`env.nu`** — replaced `default "ifiokjr"` fallback with `(whoami)` for dynamic username detection.