### PR TITLE
feat(pi): sync agent settings and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ tuckr status                   # Check deployment status of all groups
 ```bash
 # Rebuild system configuration (automatically runs via post_nix hook)
 # macOS: darwin-rebuild switch, Linux: home-manager switch
+# Successful runs also sync managed global pnpm packages
 rebuild
 
 # Or let the hook handle it
@@ -105,7 +106,7 @@ vim <dotfiles-repo>/Configs/nushell/.config/nushell/config.nu
 
 ## Configuration Groups
 
-The repository contains 15 configuration groups organized in `Configs/`:
+The repository contains 17 configuration groups organized in `Configs/`:
 
 | Group       | Platform | Purpose                                         | Hook      |
 | ----------- | -------- | ----------------------------------------------- | --------- |
@@ -120,6 +121,8 @@ The repository contains 15 configuration groups organized in `Configs/`:
 | **ghostty** | All      | Ghostty terminal emulator config                | None      |
 | **zellij**  | All      | Terminal multiplexer config & layouts           | None      |
 | **direnv**  | All      | Directory-specific environment variables        | None      |
+| **pnpm**    | All      | Managed global pnpm package set                 | `post.sh` |
+| **pi**      | All      | Pi coding agent configuration                   | None      |
 | **dprint**  | All      | Multi-language code formatter                   | None      |
 | **kdl**     | All      | KDL document formatter                          | None      |
 | **lazygit** | All      | Git TUI configuration                           | None      |
@@ -147,6 +150,8 @@ The repository contains 15 configuration groups organized in `Configs/`:
 │   ├── ghostty/               # Ghostty terminal config
 │   ├── zellij/                # Terminal multiplexer
 │   ├── direnv/                # Environment management
+│   ├── pnpm/                  # Managed global pnpm package manifest
+│   ├── pi/                    # Pi coding agent config
 │   ├── dprint/                # Code formatter
 │   ├── kdl/                   # KDL formatter
 │   ├── lazygit/               # Git TUI
@@ -154,6 +159,7 @@ The repository contains 15 configuration groups organized in `Configs/`:
 ├── Hooks/                      # Pre/post deployment scripts
 │   ├── nix/post.sh            # Rebuilds system after Nix changes
 │   ├── nushell/post.sh        # Generates vendor autoload, sets default shell
+│   ├── pnpm/post.sh           # Syncs managed global pnpm packages
 │   └── claude/post.sh         # Registers MCP server, caches Deno deps
 ├── setup                       # Automated setup script
 ├── setup-tuckr-symlink.sh     # Bootstrap script for platform symlink
@@ -183,7 +189,8 @@ Hooks are organized as `Hooks/<group>/pre.sh`, `Hooks/<group>/post.sh`, or `Hook
 
 1. **`Hooks/nix/post.sh`** - Automatically rebuilds system configuration after Nix config deployment (darwin-rebuild on macOS, home-manager switch on Linux)
 2. **`Hooks/nushell/post.sh`** - Generates vendor autoload scripts (starship, carapace, atuin, mise, zoxide), sets nushell as default shell via chsh, creates macOS config symlink
-3. **`Hooks/claude/post.sh`** - Registers tart-vm MCP server with Claude Code, caches Deno dependencies
+3. **`Hooks/pnpm/post.sh`** - Syncs managed pnpm global manifests and installs global packages
+4. **`Hooks/claude/post.sh`** - Registers tart-vm MCP server with Claude Code, caches Deno dependencies
 
 ## Nushell Development Notes
 

--- a/Configs/pi/.pi/agent/settings.json
+++ b/Configs/pi/.pi/agent/settings.json
@@ -1,9 +1,19 @@
 {
 	"lastChangelogVersion": "0.57.1",
-	"defaultProvider": "anthropic",
-	"defaultModel": "claude-opus-4-6",
+	"defaultProvider": "openai-codex",
+	"defaultModel": "gpt-5.4",
 	"defaultThinkingLevel": "xhigh",
 	"packages": [
-		"npm:@ifi/oh-pi"
+		"npm:@ifi/oh-pi",
+		{
+			"source": "npm:@ifi/oh-pi-extensions",
+			"extensions": [
+				"-extensions/safe-guard.ts"
+			]
+		},
+		"npm:@ifi/oh-pi-ant-colony",
+		"npm:@ifi/oh-pi-themes",
+		"npm:@ifi/oh-pi-prompts",
+		"npm:@ifi/oh-pi-skills"
 	]
 }

--- a/Configs/pi/.tuckrignore
+++ b/Configs/pi/.tuckrignore
@@ -1,3 +1,4 @@
 .pi/agent/auth.json
 .pi/agent/sessions/
 .pi/agent/.update-check
+.pi/agent/usage-tracker-history.json

--- a/readme.md
+++ b/readme.md
@@ -91,7 +91,7 @@ The repo can be cloned anywhere. The `setup-tuckr-symlink.sh` script creates a p
 
 **Location:** `Configs/scripts/.local/bin/` **Deploys:** `~/.local/bin/` **Description:** Custom utility scripts including:
 
-- `rebuild` - Cross-platform system rebuild (darwin-rebuild on macOS, home-manager switch on Linux); use `rebuild --update` to refresh `flake.lock` before rebuilding
+- `rebuild` - Cross-platform system rebuild (darwin-rebuild on macOS, home-manager switch on Linux); successful runs also sync managed global pnpm packages, and `rebuild --update` refreshes `flake.lock` before rebuilding
 - `generate-machine-config` - Auto-detect and generate machine.nix for Nix configuration
 - `update:node` - Update Node.js to latest version using pnpm env
 - `pnpm:global:sync` - Symlink global pnpm manifests and install pinned global packages
@@ -124,6 +124,10 @@ The repo can be cloned anywhere. The `setup-tuckr-symlink.sh` script creates a p
 **Location:** `Configs/pnpm/.config/pnpm-global/` **Deploys:** `~/.config/pnpm-global/` **Description:** Managed global pnpm manifest (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) for deterministic global package installs on macOS and Linux.
 
 **Hook:** `post_pnpm` - Resolves pnpm's active global directory and symlinks/installs the managed global package set.
+
+#### `pi`
+
+**Location:** `Configs/pi/.pi/` **Deploys:** `~/.pi/` **Description:** Pi coding agent configuration including global settings, keybindings, package sources, and symlinked custom skills.
 
 #### `dprint`
 
@@ -355,7 +359,7 @@ rebuild --lite
 rebuild --no-lite
 ```
 
-The `rebuild` script increases the file descriptor limit to 10,240 before running on macOS.
+The `rebuild` script increases the file descriptor limit to 10,240 before running on macOS, and successful runs explicitly sync managed global pnpm packages.
 
 **Solution (Manual rebuild on macOS):**
 
@@ -433,6 +437,10 @@ tuckr set pnpm
 ```
 
 to sync `~/.config/pnpm-global` into pnpm's active global directory (resolved from `pnpm root -g`) and install packages from the committed lockfile.
+
+The sync script also strips pnpm-generated `dependenciesMeta.*.node` entries from the managed manifest and lockfile, so machine-specific Node.js paths are not committed.
+
+Successful `rebuild` runs invoke the same managed sync explicitly, so global CLI packages like Pi stay installed after Nix/home-manager updates.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- sync the committed Pi settings with the current local agent configuration
- ignore Pi usage tracker history in the managed config set
- document the Pi group and managed pnpm/rebuild behavior in repo docs

## Verification
- `dprint check --config Configs/dprint/dprint.json CLAUDE.md Configs/pi/.pi/agent/settings.json Configs/pi/.tuckrignore readme.md`
