### PR TITLE
fix(nix): move codexbar from brews to casks

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -86,9 +86,6 @@
         "--verbose"
       ];
     };
-    brews = lib.optionals (!lite) [
-      "steipete/tap/codexbar"
-    ];
     casks = lib.optionals (!lite) [
       # Productivity & Communication
       "1password"
@@ -125,6 +122,7 @@
       "blender"
       "obs"
       "ollama-app"
+      "steipete/tap/codexbar"
       "vlc"
 
       # Utilities


### PR DESCRIPTION
## Summary
- Move `steipete/tap/codexbar` from `homebrew.brews` to `homebrew.casks` in `darwin.nix`
- codexbar is a cask (GUI app), not a formula — using `brew` entry caused: `formula requires at least a URL`

## Validation
- `nix flake check ./Configs/nix/.config/nix --impure --no-build` ✅
- Generated Brewfile now contains `cask "steipete/tap/codexbar"` instead of `brew "steipete/tap/codexbar"`