### PR TITLE
feat(nix): add Godot for darwin and linux installs

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -106,6 +106,7 @@
       "db-browser-for-sqlite"
       "dbeaver-community"
       "gdevelop"
+      "godot"
       "ghostty"
       "orbstack"
       "podman-desktop"

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -189,6 +189,7 @@ in
       # Linux-only packages (macOS equivalents are in darwin.nix systemPackages)
       lib.optionals (!lite) [
         blender # broken on macOS in nixpkgs; macOS uses Homebrew casks
+        godot
         ghostty
         google-chrome
         ungoogled-chromium


### PR DESCRIPTION
## Summary\n- add `godot` to Homebrew casks in `Configs/nix/.config/nix/darwin.nix`\n- add `godot` to Linux-only Home Manager packages in `Configs/nix/.config/nix/home.nix`\n\n## Verification\n- attempted: `nix flake check ./Configs/nix/.config/nix --impure --no-build`\n- result: failed because `machine.nix` is not present in this environment (expected local gitignored file)\n