### PR TITLE
feat(nix): source godot from ifiokjr-nixpkgs

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -106,7 +106,6 @@
       "db-browser-for-sqlite"
       "dbeaver-community"
       "gdevelop"
-      "godot"
       "ghostty"
       "orbstack"
       "podman-desktop"

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -169,6 +169,10 @@ in
       nerd-fonts.sauce-code-pro
       nerd-fonts.symbols-only
     ]
+    ++ lib.optionals (!lite) [
+      # Cross-platform packages from ifiokjr/nixpkgs
+      extra.godot
+    ]
     ++ lib.optionals pkgs.stdenv.isDarwin (
       [
         # macOS-only packages
@@ -189,7 +193,6 @@ in
       # Linux-only packages (macOS equivalents are in darwin.nix systemPackages)
       lib.optionals (!lite) [
         blender # broken on macOS in nixpkgs; macOS uses Homebrew casks
-        godot
         ghostty
         google-chrome
         ungoogled-chromium


### PR DESCRIPTION
## Summary
- remove `godot` Homebrew cask from `Configs/nix/.config/nix/darwin.nix`
- remove `godot` from Linux-only `pkgs` list in `Configs/nix/.config/nix/home.nix`
- add cross-platform `extra.godot` (from `ifiokjr-nixpkgs`) to `home.nix`
- keep Godot behind `!lite` so package behavior stays consistent with existing non-lite app installs

## Verification
- `dprint check --config Configs/dprint/dprint.json`
- attempted: `nix flake check ./Configs/nix/.config/nix --impure --no-build` (fails in this environment because `machine.nix` is missing, expected gitignored local file)
