### PR TITLE
fix(ci): avoid pnpm sync failure in lite setup

### DIFF
--- a/Configs/scripts/.local/bin/pnpm:global:sync
+++ b/Configs/scripts/.local/bin/pnpm:global:sync
@@ -173,9 +173,10 @@ case ":$PATH:" in
   *) export PATH="$PNPM_HOME:$PATH" ;;
 esac
 
+SANITIZE_MANIFESTS=true
 if ! command -v node >/dev/null 2>&1; then
-  fail "node is not installed; cannot sanitize pnpm global manifests"
-  exit $?
+  SANITIZE_MANIFESTS=false
+  warn "node is not installed; skipping pnpm global manifest sanitization"
 fi
 
 SOURCE_DIR="$HOME/.config/pnpm-global"
@@ -186,8 +187,10 @@ fi
 
 # pnpm may add dependenciesMeta.*.node during global installs, which hardcodes
 # a machine-specific Node.js path into the managed manifest and lockfile.
-sanitize_manifest_dependencies_meta "$SOURCE_DIR/package.json"
-sanitize_lockfile_dependencies_meta "$SOURCE_DIR/pnpm-lock.yaml"
+if [ "$SANITIZE_MANIFESTS" = true ]; then
+  sanitize_manifest_dependencies_meta "$SOURCE_DIR/package.json"
+  sanitize_lockfile_dependencies_meta "$SOURCE_DIR/pnpm-lock.yaml"
+fi
 
 if ! GLOBAL_ROOT="$(pnpm root -g 2>/dev/null)"; then
   fail "Failed to resolve pnpm global root with 'pnpm root -g'"
@@ -221,7 +224,9 @@ if ! pnpm "${INSTALL_ARGS[@]}"; then
   exit $?
 fi
 
-sanitize_manifest_dependencies_meta "$SOURCE_DIR/package.json"
-sanitize_lockfile_dependencies_meta "$SOURCE_DIR/pnpm-lock.yaml"
+if [ "$SANITIZE_MANIFESTS" = true ]; then
+  sanitize_manifest_dependencies_meta "$SOURCE_DIR/package.json"
+  sanitize_lockfile_dependencies_meta "$SOURCE_DIR/pnpm-lock.yaml"
+fi
 
 info "pnpm global packages synced"

--- a/Hooks/nix/post.sh
+++ b/Hooks/nix/post.sh
@@ -299,8 +299,14 @@ if [ "$REBUILD_EXIT" -eq 0 ]; then
 	fi
 
 	if [ -x "$PNPM_SYNC_SCRIPT" ]; then
+		SYNC_ARGS=()
+		if [ "$CFG_LITE" = "true" ]; then
+			echo "Lite mode enabled; running pnpm global sync in best-effort mode"
+			SYNC_ARGS+=(--no-fail)
+		fi
+
 		echo "Syncing managed pnpm global packages..."
-		if ! "$PNPM_SYNC_SCRIPT"; then
+		if ! "$PNPM_SYNC_SCRIPT" "${SYNC_ARGS[@]}"; then
 			echo "ERROR: managed pnpm global package sync failed"
 			REBUILD_EXIT=1
 		fi


### PR DESCRIPTION
## Summary
- make `pnpm:global:sync` skip manifest sanitization when `node` is unavailable instead of failing early
- keep pnpm global install/link behavior intact
- run strict pnpm sync only outside lite mode; in lite mode run best-effort (`--no-fail`) during nix post-hook

## Verification
- `shellcheck setup setup-tuckr-symlink.sh Hooks/*/post.sh`
- `shellcheck Configs/scripts/.local/bin/pnpm:global:sync`
- simulated no-node environment run of `pnpm:global:sync --quiet` returned exit 0
