### PR TITLE
feat(nix): add secretspec to home-manager packages

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -69,6 +69,7 @@ in
       extra.mdt
       extra.racket-minimal
       rustup
+      secretspec
       spec-kit
 
       # Shell & Terminal


### PR DESCRIPTION
Add [secretspec](https://github.com/cachix/secretspec) to home-manager packages.

SecretSpec provides declarative secrets management — separating secret declaration (`secretspec.toml`) from secret storage (keyring, 1Password, AWS Secrets Manager, etc.).

Available in nixpkgs-unstable as `pkgs.secretspec`.