### PR TITLE
feat(rebuild): log package version changes after rebuild

### DIFF
--- a/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
+++ b/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
@@ -1,0 +1,135 @@
+# version_tracker.nu - Track package version changes across rebuilds
+#
+# Captures "before" and "after" snapshots of installed packages and computes diffs.
+# Supports Nix (home-manager + nix-darwin closures), pnpm globals, and Homebrew.
+# ─────────────────────────────────────────────────────────────────────────────
+# Nix profiles
+# ─────────────────────────────────────────────────────────────────────────────
+# Resolve a symlink to its final store path.
+def resolve-store-path [profile: string] {
+    if ($profile | path exists) {
+        (^readlink -f $profile | str trim)
+    } else {
+        null
+    }
+}
+# Capture the current home-manager activation store path.
+export def capture-hm-profile [] { resolve-store-path $"($env.HOME)/.local/state/nix/profiles/home-manager" }
+# Capture the current nix-darwin system store path.
+export def capture-darwin-profile [] { resolve-store-path "/nix/var/nix/profiles/system" }
+# Run `nix store diff-closures` between two store paths.
+# Returns the raw text output (each line is one changed derivation).
+export def diff-nix-closures [old_path: string, new_path: string] {
+    if ($old_path | is-empty) or ($new_path | is-empty) {
+        return null
+    }
+    let result = do -i { ^nix store diff-closures $old_path $new_path }
+    if ($env.LAST_EXIT_CODE != 0) {
+        return null
+    }
+    $result | lines | where $it != ""
+}
+# ─────────────────────────────────────────────────────────────────────────────
+# pnpm globals
+# ─────────────────────────────────────────────────────────────────────────────
+# Return a list of {name, version} records for globally installed pnpm packages.
+export def capture-pnpm-globals [] {
+    if (which pnpm | is-empty) { return null }
+    let result = do -i { ^pnpm list -g --json }
+    if ($env.LAST_EXIT_CODE != 0) { return null }
+    let parsed = try {
+        $result | from json
+    } catch { return null }
+    if ($parsed | is-empty) { return null }
+    let root = if ($parsed | describe) == "list" {
+        $parsed | get 0
+    } else {
+        $parsed
+    }
+    let deps = try {
+        $root | get --optional dependencies
+    } catch { return null }
+    if ($deps | is-empty) { return null }
+    $deps | items { |name, info| { name: $name, version: $info.version } }
+}
+# ─────────────────────────────────────────────────────────────────────────────
+# Homebrew
+# ─────────────────────────────────────────────────────────────────────────────
+# Return a list of {name, version} records for installed Homebrew formulae/casks.
+export def capture-brew-packages [] {
+    if (which brew | is-empty) { return null }
+    let result = do -i { ^brew list --versions }
+    if ($env.LAST_EXIT_CODE != 0) { return null }
+    $result | lines | where $it != "" | parse "{name} {version}" | default "" version
+}
+# ─────────────────────────────────────────────────────────────────────────────
+# Generic diff helpers
+# ─────────────────────────────────────────────────────────────────────────────
+# Diff two lists of {name, version} records.
+# Returns {added: [...], removed: [...], changed: [...]} where each item is:
+#   {name, old, new}
+export def diff-package-lists [old: list<any>, new: list<any>] {
+    let old_map = ($old | default [] | reduce -f {} {|it, acc| $acc | insert $it.name $it.version })
+    let new_map = ($new | default [] | reduce -f {} {|it, acc| $acc | insert $it.name $it.version })
+    let added = ($new_map | items { |name, ver| { name: $name, old: "", new: $ver } } | where { |it| not ($it.name in ($old_map | columns)) })
+    let removed = ($old_map | items { |name, ver| { name: $name, old: $ver, new: "" } } | where { |it| not ($it.name in ($new_map | columns)) })
+    let changed = ($new_map | items { |name, ver| { name: $name, old: ($old_map | get --optional $name | default ""), new: $ver } } | where { |it| ($it.old != "") and ($it.old != $it.new) })
+    {
+        added: $added
+        removed: $removed
+        changed: $changed
+    }
+}
+# ─────────────────────────────────────────────────────────────────────────────
+# Pretty-print helpers
+# ─────────────────────────────────────────────────────────────────────────────
+# Print a package diff returned by diff-package-lists.
+export def print-package-diff [diff: record, title: string] {
+    let total = ($diff.added | length) + ($diff.removed | length) + ($diff.changed | length)
+    if $total == 0 { return }
+    header $title
+    for pkg in $diff.added { success $"  + ($pkg.name) ($pkg.new)" }
+    for pkg in $diff.removed { err $"  - ($pkg.name) ($pkg.old)" }
+    for pkg in $diff.changed { info $"  ~ ($pkg.name): ($pkg.old) → ($pkg.new)" }
+}
+# Print a raw Nix closure diff (list of strings). Filters out noise lines.
+export def print-nix-diff [lines: list<string>, title: string] {
+    if ($lines | is-empty) { return }
+    # Filter out empty lines and lines with no actual change indicator
+    let meaningful = ($lines | where { |it| ($it | str contains "→") or ($it | str contains "+") or ($it | str contains "-") })
+    if ($meaningful | is-empty) { return }
+    header $title
+    for line in $meaningful {
+        if ($line | str contains "→") {
+            info $"  ($line)"
+        } else if ($line | str starts-with "+") {
+            success $"  ($line)"
+        } else if ($line | str starts-with "-") {
+            err $"  ($line)"
+        } else {
+            print $"  ($line)"
+        }
+    }
+}
+# ─────────────────────────────────────────────────────────────────────────────
+# Persistent log
+# ─────────────────────────────────────────────────────────────────────────────
+# Append a rebuild summary to a persistent log file.
+# `sections` is a list of strings (already formatted).
+export def log-rebuild-summary [sections: list<string>, --log-file: string] {
+    let file = if ($log_file | is-empty) {
+        $"($env.HOME)/.local/share/dotfiles/rebuild-changes.log"
+    } else {
+        $log_file
+    }
+    mkdir ($file | path dirname)
+    let timestamp = (date now | format date "%Y-%m-%d %H:%M:%S")
+    let sep = "═══════════════════════════════════════════════════════════════════════════════"
+    let lines = [
+        $sep
+        $"Rebuild Summary — ($timestamp)"
+        $sep
+        ""
+    ] | append $sections | append ["", ""]
+    $lines | str join "\n" | save --append $file
+}

--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -7,6 +7,7 @@
 use nu_modules/print_utils.nu *
 use nu_modules/platform.nu
 use nu_modules/nix_config.nu
+use nu_modules/version_tracker.nu
 
 def sync_pnpm_global_packages [] {
     let primary_sync_script = $"($env.HOME)/.local/bin/pnpm:global:sync"
@@ -271,6 +272,12 @@ def main [
         }
     }
 
+    # ── Capture package state before rebuild ─────────────────────────────────
+    let before_hm = (version_tracker capture-hm-profile)
+    let before_darwin = (version_tracker capture-darwin-profile)
+    let before_pnpm = (version_tracker capture-pnpm-globals)
+    let before_brew = if $os == "darwin" { (version_tracker capture-brew-packages) } else { null }
+
     if $os == "darwin" {
         ensure_darwin_sudo_session
 
@@ -362,4 +369,67 @@ def main [
             exit 1
         }
     }
+
+    # ── Diff and display package version changes ───────────────────────────────
+    let after_hm = (version_tracker capture-hm-profile)
+    let after_darwin = (version_tracker capture-darwin-profile)
+    let after_pnpm = (version_tracker capture-pnpm-globals)
+    let after_brew = if $os == "darwin" { (version_tracker capture-brew-packages) } else { null }
+
+    mut log_lines = []
+
+    # Nix darwin system closure diff
+    if $os == "darwin" and ($before_darwin | is-not-empty) and ($after_darwin | is-not-empty) {
+        let nix_diff = (version_tracker diff-nix-closures $before_darwin $after_darwin)
+        if ($nix_diff | is-not-empty) {
+            print ""
+            version_tracker print-nix-diff $nix_diff "Nix system closure changes"
+            $log_lines = ($log_lines | append ["Nix system closure changes:"] | append $nix_diff)
+        }
+    }
+
+    # Nix home-manager closure diff
+    if ($before_hm | is-not-empty) and ($after_hm | is-not-empty) {
+        let hm_diff = (version_tracker diff-nix-closures $before_hm $after_hm)
+        if ($hm_diff | is-not-empty) {
+            print ""
+            version_tracker print-nix-diff $hm_diff "Home-manager closure changes"
+            $log_lines = ($log_lines | append ["Home-manager closure changes:"] | append $hm_diff)
+        }
+    }
+
+    # pnpm global diff
+    if ($before_pnpm | is-not-empty) or ($after_pnpm | is-not-empty) {
+        let pnpm_diff = (version_tracker diff-package-lists $before_pnpm $after_pnpm)
+        let pnpm_total = ($pnpm_diff.added | length) + ($pnpm_diff.removed | length) + ($pnpm_diff.changed | length)
+        if $pnpm_total > 0 {
+            print ""
+            version_tracker print-package-diff $pnpm_diff "pnpm global package changes"
+            $log_lines = ($log_lines | append ["pnpm global package changes:"])
+            $log_lines = ($log_lines | append ($pnpm_diff.added | each { |it| $"  + ($it.name) ($it.new)" }))
+            $log_lines = ($log_lines | append ($pnpm_diff.removed | each { |it| $"  - ($it.name) ($it.old)" }))
+            $log_lines = ($log_lines | append ($pnpm_diff.changed | each { |it| $"  ~ ($it.name): ($it.old) -> ($it.new)" }))
+        }
+    }
+
+    # Homebrew diff
+    if $os == "darwin" and (($before_brew | is-not-empty) or ($after_brew | is-not-empty)) {
+        let brew_diff = (version_tracker diff-package-lists $before_brew $after_brew)
+        let brew_total = ($brew_diff.added | length) + ($brew_diff.removed | length) + ($brew_diff.changed | length)
+        if $brew_total > 0 {
+            print ""
+            version_tracker print-package-diff $brew_diff "Homebrew package changes"
+            $log_lines = ($log_lines | append ["Homebrew package changes:"])
+            $log_lines = ($log_lines | append ($brew_diff.added | each { |it| $"  + ($it.name) ($it.new)" }))
+            $log_lines = ($log_lines | append ($brew_diff.removed | each { |it| $"  - ($it.name) ($it.old)" }))
+            $log_lines = ($log_lines | append ($brew_diff.changed | each { |it| $"  ~ ($it.name): ($it.old) -> ($it.new)" }))
+        }
+    }
+
+    # Persist changes to log file
+    if ($log_lines | is-not-empty) {
+        version_tracker log-rebuild-summary $log_lines
+    }
+
+    print ""
 }


### PR DESCRIPTION
Track version changes across rebuilds by capturing before/after snapshots of installed packages and displaying diffs.

## What gets tracked

| Package source | Detection method |
|---|---|
| **Nix system** (macOS) | `nix store diff-closures` on darwin system profile |
| **Home-manager** | `nix store diff-closures` on home-manager profile |
| **pnpm global** | `pnpm list -g --json` parsed before/after |
| **Homebrew** | `brew list --versions` parsed before/after |

## Output example

After a successful rebuild, you'll see something like:

```
Home-manager closure changes
  curl: 8.6.0 → 8.12.1, +139.7 KiB
  libssh2: 1.11.0 → 1.11.1, +12.3 KiB

pnpm global package changes
  ~ @antfu/ni: 0.21.8 → 0.22.0
```

## Persistent log

All changes are appended to `~/.local/share/dotfiles/rebuild-changes.log` with timestamps, so you have a running history of what's changed across every rebuild.

## Edge cases handled

- **First rebuild / no prior profile**: silently skips diff for that category
- **Rebuild fails**: no diff is shown (you'd see the error first)
- **No `nix store diff-closures`**: silently skipped
- **Missing `pnpm` or `brew`**: silently skipped

## Files changed

- `Configs/scripts/.local/bin/nu_modules/version_tracker.nu` (new, 135 lines)
- `Configs/scripts/.local/bin/rebuild` (+70 lines)
