### PR TITLE
fix(version_tracker): handle varying pnpm --json output shapes

### DIFF
--- a/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
+++ b/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
@@ -41,7 +41,7 @@ export def capture-pnpm-globals [] {
         $result | from json
     } catch { return null }
     if ($parsed | is-empty) { return null }
-    let root = if ($parsed | describe) == "list" {
+    let root = if ($parsed | describe | str contains "list") {
         $parsed | get 0
     } else {
         $parsed
@@ -49,8 +49,13 @@ export def capture-pnpm-globals [] {
     let deps = try {
         $root | get --optional dependencies
     } catch { return null }
-    if ($deps | is-empty) { return null }
-    $deps | items { |name, info| { name: $name, version: $info.version } }
+    let deps_type = try {
+        $deps | describe
+    } catch { "nothing" }
+    if ($deps_type | str contains "nothing") or (not ($deps_type | str starts-with "record")) {
+        return null
+    }
+    $deps | items { |name, info| { name: $name, version: ($info | get --optional version | default "") } }
 }
 # ─────────────────────────────────────────────────────────────────────────────
 # Homebrew


### PR DESCRIPTION
Fix a crash during `rebuild --update` where `capture-pnpm-globals` fails because `pnpm list -g --json` output shape varies by pnpm version.

## Root causes

1. `($parsed | describe) == "list"` never matched because Nushell returns `"list<any>"`, not `"list"`. This meant `$root` stayed as the full pnpm output table, and `$root | get --optional dependencies` on a list/table returned `list<nothing>` (a list of nulls) instead of the expected record.

2. `items` only works on records, but the code blindly passed `$deps` without checking its type first.

## Changes

- Use `$parsed | describe | str contains "list"` so the unwrap works for any list shape.
- Added a `$deps_type` guard: only call `items` when `$deps` is a record. Any other shape (table, list, `list<nothing>`, etc.) is skipped safely.
- Switched `$info.version` to `$info | get --optional version` to avoid crashes when a record lacks a `version` key.

## Files changed

- `Configs/scripts/.local/bin/nu_modules/version_tracker.nu` (+6, -3)