### PR TITLE
ci: install taplo for dprint TOML formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: 📦 install lint tools
         run: |
           nix profile add nixpkgs#shellcheck nixpkgs#dprint nixpkgs#nushell \
-            nixpkgs#shfmt nixpkgs#nixfmt nixpkgs#kdlfmt nixpkgs#nufmt \
+            nixpkgs#shfmt nixpkgs#nixfmt nixpkgs#kdlfmt nixpkgs#nufmt nixpkgs#taplo \
             nixpkgs#racket
           # Add nix profile to GITHUB_PATH for subsequent steps
           echo "$HOME/.nix-profile/bin" >> "$GITHUB_PATH"

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,7 @@
+# Taplo configuration for dprint exec plugin
+# Aligns with dprint.json: useTabs=true, indentWidth=2
+
+[formatting]
+indent_string = "\t"
+reorder_keys = false
+align_entries = false

--- a/Configs/helix/.config/helix/config.toml
+++ b/Configs/helix/.config/helix/config.toml
@@ -8,7 +8,7 @@ completion-replace = true
 completion-timeout = 5
 # end-of-line-diagnostics = "hint"
 line-number = "relative"
-mouse = true # works better with zellij for isolating selections
+mouse = true             # works better with zellij for isolating selections
 shell = ["bash", "-c"]
 
 [editor.statusline]

--- a/Configs/helix/.config/helix/languages.toml
+++ b/Configs/helix/.config/helix/languages.toml
@@ -92,7 +92,13 @@ auto-format = true
 
 [[language]]
 name = "rust"
-language-servers = [{ name = "testing-ls", only-features = ["diagnostics"] }, "rust-analyzer", "tailwindcss-ls"]
+language-servers = [
+	{ name = "testing-ls", only-features = [
+		"diagnostics",
+	] },
+	"rust-analyzer",
+	"tailwindcss-ls",
+]
 indent = { tab-width = 2, unit = "\t" }
 formatter = { command = "dprint", args = ["fmt", "--stdin", "%{buffer_name}"] }
 auto-format = true
@@ -118,7 +124,9 @@ completion = [{ name = "binary", completion = "filename" }]
 
 [language.debugger.templates.args]
 program = "{0}"
-initCommands = ["command script import /usr/local/etc/lldb_vscode_rustc_primer.py"]
+initCommands = [
+	"command script import /usr/local/etc/lldb_vscode_rustc_primer.py",
+]
 
 [[language.debugger.templates]]
 name = "binary (terminal)"
@@ -128,7 +136,9 @@ completion = [{ name = "binary", completion = "filename" }]
 [language.debugger.templates.args]
 program = "{0}"
 runInTerminal = true
-initCommands = ["command script import /usr/local/etc/lldb_vscode_rustc_primer.py"]
+initCommands = [
+	"command script import /usr/local/etc/lldb_vscode_rustc_primer.py",
+]
 
 [[language.debugger.templates]]
 name = "attach"
@@ -137,7 +147,9 @@ completion = ["pid"]
 
 [language.debugger.templates.args]
 pid = "{0}"
-initCommands = ["command script import /usr/local/etc/lldb_vscode_rustc_primer.py"]
+initCommands = [
+	"command script import /usr/local/etc/lldb_vscode_rustc_primer.py",
+]
 
 [[language.debugger.templates]]
 name = "gdbserver attach"
@@ -155,7 +167,9 @@ attachCommands = [
 	"file {1}",
 	"attach {2}",
 ]
-initCommands = ["command script import /usr/local/etc/lldb_vscode_rustc_primer.py"]
+initCommands = [
+	"command script import /usr/local/etc/lldb_vscode_rustc_primer.py",
+]
 
 [[language]]
 name = "scheme"
@@ -220,7 +234,9 @@ name = "typescript"
 indent = { tab-width = 2, unit = "\t" }
 roots = ["deno.json", "deno.jsonc", "package.json"]
 language-servers = [
-	{ name = "testing-ls", only-features = ["diagnostics"] },
+	{ name = "testing-ls", only-features = [
+		"diagnostics",
+	] },
 	"typescript-language-server",
 	"vscode-eslint-language-server",
 	"deno-lsp",
@@ -232,7 +248,9 @@ auto-format = true
 name = "tsx"
 indent = { tab-width = 2, unit = "\t" }
 language-servers = [
-	{ name = "testing-ls", only-features = ["diagnostics"] },
+	{ name = "testing-ls", only-features = [
+		"diagnostics",
+	] },
 	"tailwindcss-ls",
 	"typescript-language-server",
 	"vscode-eslint-language-server",
@@ -245,7 +263,9 @@ auto-format = true
 name = "javascript"
 indent = { tab-width = 2, unit = "\t" }
 language-servers = [
-	{ name = "testing-ls", only-features = ["diagnostics"] },
+	{ name = "testing-ls", only-features = [
+		"diagnostics",
+	] },
 	"typescript-language-server",
 	"vscode-eslint-language-server",
 	"deno-lsp",
@@ -257,7 +277,9 @@ auto-format = true
 name = "jsx"
 indent = { tab-width = 2, unit = "\t" }
 language-servers = [
-	{ name = "testing-ls", only-features = ["diagnostics"] },
+	{ name = "testing-ls", only-features = [
+		"diagnostics",
+	] },
 	"tailwindcss-ls",
 	"typescript-language-server",
 	"vscode-eslint-language-server",

--- a/Configs/yazi/.config/yazi/keymap.toml
+++ b/Configs/yazi/.config/yazi/keymap.toml
@@ -1,4 +1,6 @@
 [mgr]
 prepend_keymap = [
-	{ on = ["<A-e>"], run = "shell 'zellij action focus-next-pane' --confirm", desc = "Focus editor pane" },
+	{ on = [
+		"<A-e>",
+	], run = "shell 'zellij action focus-next-pane' --confirm", desc = "Focus editor pane" },
 ]


### PR DESCRIPTION
The dprint config uses `taplo` via the exec plugin to format `.toml` files, but `taplo` was not installed in the CI lint job. This caused dprint to fail with "Cannot start formatter process: No such file or directory" for every `.toml` file.

## Change

Install `nixpkgs#taplo` alongside the other lint/formatting tools in `ci.yml`.

## Files changed

- `.github/workflows/ci.yml` (+1)
