### PR TITLE
fix(devenv): skip removed hook command on shell startup

### DIFF
--- a/Configs/bash/.bashrc
+++ b/Configs/bash/.bashrc
@@ -32,7 +32,7 @@ if command -v direnv &>/dev/null; then
 	eval "$(direnv hook bash)"
 fi
 
-if command -v devenv &>/dev/null; then
+if command -v devenv &>/dev/null && devenv --help 2>/dev/null | grep -Eq '^[[:space:]]+hook[[:space:]]'; then
 	eval "$(devenv hook bash)"
 fi
 

--- a/Configs/nushell/.config/nushell/config.nu
+++ b/Configs/nushell/.config/nushell/config.nu
@@ -60,10 +60,7 @@ $env.config = {
         }
     }
 }
-# Devenv 2.1+ auto-activation for trusted devenv projects.
-mkdir ~/.cache/devenv
-devenv hook nu | save --force ~/.cache/devenv/hook.nu
-source ~/.cache/devenv/hook.nu
+# Devenv 2.x no longer exposes `devenv hook`; use `devenv shell` or direnv per-project instead.
 # Auto-activate Node.js from pnpm-workspace.yaml useNodeVersion (pnpm-standalone)
 def --env pnpm_auto_activate [] {
     let debug = ($env | get -o DOTFILES_DEBUG | is-not-empty)

--- a/Configs/zsh/.zshrc
+++ b/Configs/zsh/.zshrc
@@ -59,7 +59,7 @@ if command -v direnv &>/dev/null; then
 	eval "$(direnv hook zsh)"
 fi
 
-if command -v devenv &>/dev/null; then
+if command -v devenv &>/dev/null && devenv --help 2>/dev/null | grep -Eq '^[[:space:]]+hook[[:space:]]'; then
 	eval "$(devenv hook zsh)"
 fi
 

--- a/Hooks/nushell/post.sh
+++ b/Hooks/nushell/post.sh
@@ -54,19 +54,8 @@ if [ -x "$NU_PATH" ]; then
 	VENDOR_AUTOLOAD_DIR=$("$NU_PATH" -c '$nu.data-dir | path join "vendor/autoload"')
 	mkdir -p "$VENDOR_AUTOLOAD_DIR"
 
-	# Generate devenv auto-activation hook so config.nu can source it on startup.
-	if command -v devenv &>/dev/null; then
-		DEVENV_HOOK_FILE="$HOME/.cache/devenv/hook.nu"
-		mkdir -p "$(dirname "$DEVENV_HOOK_FILE")"
-		if devenv hook nu >"$DEVENV_HOOK_FILE" 2>/dev/null; then
-			echo -e "${GREEN}✓${NC} Generated devenv hook.nu"
-		else
-			rm -f "$DEVENV_HOOK_FILE"
-			echo -e "${YELLOW}!${NC} devenv hook nu failed, skipping hook.nu"
-		fi
-	else
-		echo -e "${YELLOW}!${NC} devenv not found, skipping hook.nu"
-	fi
+	# Devenv 2.x no longer exposes `devenv hook`; do not generate stale startup hooks.
+	rm -f "$HOME/.cache/devenv/hook.nu"
 
 	# Generate starship init (per https://starship.rs/guide/)
 	if command -v starship &>/dev/null; then


### PR DESCRIPTION
## Summary

Devenv 2.x no longer exposes the `devenv hook` subcommand. Our shell startup files still called it, causing every new terminal to print:

```
error: unrecognized subcommand 'hook'
```

## Changes

- Guard bash/zsh `devenv hook` setup so it only runs if the installed devenv advertises a `hook` command.
- Remove the unconditional Nushell startup `devenv hook nu` generation/source.
- Update the nushell post hook to remove stale cached `~/.cache/devenv/hook.nu` instead of generating a stale/unsupported hook.

## Verification

- `dprint check --config Configs/dprint/dprint.json`
- `shellcheck setup setup-tuckr-symlink.sh Hooks/*/post.sh`
- `nu -c "nu-check Configs/nushell/.config/nushell/config.nu"`
