### PR TITLE
feat(ghostty): add ghostty to dev preset for --lite inclusion

### DIFF
--- a/Configs/ghostty.group.toml
+++ b/Configs/ghostty.group.toml
@@ -1,2 +1,2 @@
 description = "Ghostty terminal emulator configuration."
-presets = ["workstation"]
+presets = ["workstation", "dev"]


### PR DESCRIPTION
Ghostty is lightweight and useful even in minimal setups, so it should be available when installing with `--lite` mode.

## Change

Adds `"dev"` to the ghostty group presets so it's included in `--lite` installations (which covers core + dev + ci presets).

## Before

```toml
presets = ["workstation"]
```

## After

```toml
presets = ["workstation", "dev"]
```

Ghostty config is just static config files with no hook, so it's zero-cost to include in dev setups.