### PR TITLE
fix(rebuild): bootstrap Nix PATH before running nh

### DIFF
--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -214,13 +214,37 @@ def main [
     print $"  Lite: ($config.lite)"
     print ""
 
+    # Rebuild must work even when the user's shell has not loaded Nix yet.
+    # Put known Nix/Darwin profile locations ahead of the inherited PATH before
+    # running nix, nix-env, darwin-rebuild, or nh. nh remains the primary macOS
+    # rebuild command; this just ensures nh can find nix.
+    let current_path = if (($env.PATH | describe) | str starts-with "list") { $env.PATH } else { $env.PATH | split row (char esep) }
+    let bootstrap_path = [
+        "/nix/var/nix/profiles/default/bin"
+        "/run/current-system/sw/bin"
+        $"/etc/profiles/per-user/($config.username)/bin"
+        $"($env.HOME)/.nix-profile/bin"
+        $"($env.HOME)/.local/state/nix/profiles/home-manager/home-path/bin"
+        $"($env.HOME)/.local/bin"
+        "/usr/local/bin"
+        "/usr/bin"
+        "/bin"
+        "/usr/sbin"
+        "/sbin"
+    ]
+    $env.PATH = ($bootstrap_path | where { |dir| ($dir | path exists) } | append $current_path | uniq)
+
+    if (which nix | is-empty) {
+        err "nix not found after bootstrapping PATH; expected /nix/var/nix/profiles/default/bin/nix or /run/current-system/sw/bin/nix"
+        exit 1
+    }
+
     # Detect root-only nix install (Docker/containers without systemd).
     # When true, nix commands need sudo with HOME preserved.
     # If the nix daemon socket exists (e.g. manually started), sudo is not needed.
     let root_only_nix = (not ("/run/systemd/system" | path exists)) and (not ("/nix/var/nix/daemon-socket/socket" | path exists)) and ((^id -u | str trim) != "0")
 
     # Build the sudo prefix for nix commands when running root-only nix.
-    # Nix binaries are symlinked to /usr/local/bin by setup, so PATH isn't needed.
     let sudo_prefix = if $root_only_nix { "sudo" } else { "" }
 
     # Use resolved flake dir for nix commands so symlinked flake.nix doesn't produce invalid paths

--- a/Hooks/nix/post.sh
+++ b/Hooks/nix/post.sh
@@ -24,6 +24,33 @@ if [ -d "$HOME/.local/bin" ]; then
 	export PATH="$HOME/.local/bin:$PATH"
 fi
 
+# setup may run before the user's shell has loaded Nix. Put known Nix/Darwin
+# profile locations ahead of the inherited PATH so nh can find nix during
+# first-time bootstrap and partially-activated states.
+PROFILE_USER="${USER:-$(whoami)}"
+for p in \
+	"/nix/var/nix/profiles/default/bin" \
+	"/run/current-system/sw/bin" \
+	"/etc/profiles/per-user/${PROFILE_USER}/bin" \
+	"$HOME/.nix-profile/bin" \
+	"$HOME/.local/state/nix/profiles/home-manager/home-path/bin" \
+	"$HOME/.local/bin" \
+	"/usr/local/bin" \
+	"/usr/bin" \
+	"/bin" \
+	"/usr/sbin" \
+	"/sbin"; do
+	if [ -d "$p" ]; then
+		export PATH="$p:$PATH"
+	fi
+done
+
+if ! command -v nix >/dev/null 2>&1; then
+	echo "ERROR: nix not found after bootstrapping PATH" >&2
+	echo "Expected /nix/var/nix/profiles/default/bin/nix or /run/current-system/sw/bin/nix" >&2
+	exit 1
+fi
+
 SUDO_KEEPALIVE_PID=""
 SUDO_SESSION_READY=false
 
@@ -83,6 +110,19 @@ stop_darwin_sudo_keepalive() {
 
 trap stop_darwin_sudo_keepalive EXIT
 
+backup_for_nix_darwin() {
+	local f="$1"
+	local target
+	if [ -f "$f" ] && [ ! -L "$f" ]; then
+		target="${f}.before-nix-darwin"
+		if sudo test -e "$target"; then
+			target="${target}.$(date +%Y%m%d%H%M%S)"
+		fi
+		echo "Renaming $f → $target"
+		sudo mv "$f" "$target"
+	fi
+}
+
 # nix-darwin activation refuses to overwrite /etc files it doesn't manage.
 # Rename any conflicting files so the first nh darwin switch succeeds.
 # This includes sudoers.d files we bootstrap for global sudo timestamps —
@@ -92,10 +132,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	ensure_darwin_sudo_session
 	start_darwin_sudo_keepalive
 	for f in /etc/zshenv /etc/zshrc /etc/bashrc /etc/zprofile /etc/sudoers.d/10-nix-darwin-extra-config; do
-		if [ -f "$f" ] && [ ! -L "$f" ]; then
-			echo "Renaming $f → ${f}.before-nix-darwin"
-			sudo mv "$f" "${f}.before-nix-darwin"
-		fi
+		backup_for_nix_darwin "$f"
 	done
 fi
 


### PR DESCRIPTION
## Summary
- prepend known Nix/nix-darwin profile directories before running nix or nh in both rebuild and setup hook
- keep nh as the primary Darwin rebuild path while fixing bootstrap states where nh exists but nix is missing from PATH
- use timestamped backups for unmanaged /etc handoff files when previous .before-nix-darwin backups already exist

## Verification
- `nu Configs/scripts/.local/bin/rebuild --help`
- `shellcheck setup setup-tuckr-symlink.sh Hooks/*/post.sh`
- `dprint check --config Configs/dprint/dprint.json`
- stripped-PATH nix/nh visibility probe
- stripped-PATH `nh darwin build ... -- --no-link`
- stripped-PATH `rebuild` reaches flake check with nix before sudo prompt
- `nix flake check ./Configs/nix/.config/nix --impure`
- `nix build ./Configs/nix/.config/nix#darwinConfigurations.default.system --impure --no-link`
- simulated Mac Mini lite Darwin build