### PR TITLE
feat: add isDesktop flag with podman-based Docker for lite macOS desktops

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -5,6 +5,7 @@
   self,
   username,
   lite ? false,
+  isDesktop ? false,
   ifiokjr-nixpkgs,
   homebrew-core,
   homebrew-cask,

--- a/Configs/nix/.config/nix/flake.nix
+++ b/Configs/nix/.config/nix/flake.nix
@@ -104,6 +104,7 @@
           system ? "aarch64-darwin",
           username,
           lite ? false,
+          isDesktop ? false,
         }:
         let
           pkgs = nixpkgs.legacyPackages.${system};
@@ -118,6 +119,7 @@
                 inherit
                   username
                   lite
+                  isDesktop
                   ifiokjr-nixpkgs
                   homebrew-core
                   homebrew-cask
@@ -132,7 +134,7 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.extraSpecialArgs = {
-                inherit ifiokjr-nixpkgs lite;
+                inherit ifiokjr-nixpkgs lite isDesktop;
               };
               home-manager.users.${username} = {
                 imports = [ ./home.nix ];
@@ -149,6 +151,7 @@
           system,
           username,
           lite ? false,
+          isDesktop ? false,
           homeDirectory ? null,
         }:
         let
@@ -169,7 +172,7 @@
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = {
-            inherit ifiokjr-nixpkgs lite;
+            inherit ifiokjr-nixpkgs lite isDesktop;
           };
           modules = [
             ./home.nix
@@ -246,6 +249,7 @@
           system = machineConfig.system;
           username = machineConfig.username;
           lite = machineConfig.lite or false;
+          isDesktop = machineConfig.isDesktop or false;
         };
 
       # Standalone home-manager configuration (for Linux or non-Darwin use)
@@ -259,6 +263,7 @@
             system = machineConfig.system;
             username = machineConfig.username;
             lite = machineConfig.lite or false;
+            isDesktop = machineConfig.isDesktop or false;
           };
         };
 

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -2,6 +2,7 @@
   pkgs,
   lib,
   lite ? false,
+  isDesktop ? false,
   ifiokjr-nixpkgs,
   ...
 }:
@@ -197,7 +198,14 @@ in
         google-chrome
         ungoogled-chromium
       ]
-    );
+    )
+    ++ lib.optionals (isDesktop && lite && pkgs.stdenv.isDarwin) [
+      # Docker compatibility layer via podman (for lite macOS desktops like Mac Mini)
+      # Provides `docker` and `docker-compose` commands backed by podman
+      (pkgs.writeShellScriptBin "docker" ''exec podman "$@"'')
+      (pkgs.writeShellScriptBin "docker-compose" ''exec podman-compose "$@"'')
+      pkgs.podman-compose
+    ];
 
   # Home Manager is pretty good at managing dotfiles. The primary way to manage
   # plain files is through 'home.file'.
@@ -221,6 +229,16 @@ in
       "$HOME/.local/bin/pnpm:global:sync" --quiet --no-fail || true
     fi
   '';
+
+  # Initialize podman VM for Docker compatibility on lite macOS desktops.
+  # Idempotent: podman machine init fails silently if a machine already exists.
+  home.activation.initPodmanMachine = lib.hm.dag.entryAfter [ "writeBoundary" ] (
+    lib.optionalString (isDesktop && lite && pkgs.stdenv.isDarwin) ''
+      if command -v podman >/dev/null 2>&1; then
+        ${pkgs.podman}/bin/podman machine init 2>/dev/null || true
+      fi
+    ''
+  );
 
   # Environment variables
   home.sessionVariables = {

--- a/Configs/nix/.config/nix/machine.nix.example
+++ b/Configs/nix/.config/nix/machine.nix.example
@@ -15,4 +15,8 @@
   # Optional: Lite profile (CLI-focused, skips GUI-heavy applications)
   # Set to true when using `./setup --lite`
   lite = false;
+
+  # Optional: Desktop machine — enables Docker via podman on macOS (lite desktops)
+  # Set to true on always-plugged-in desktops (e.g. Mac Mini)
+  isDesktop = false;
 }

--- a/Configs/scripts/.local/bin/nu_modules/nix_config.nu
+++ b/Configs/scripts/.local/bin/nu_modules/nix_config.nu
@@ -30,6 +30,26 @@ export def flake-dir [] {
 }
 # Path to machine.nix
 export def machine-config-path [] { $"(config-dir)/machine.nix" }
+# Set the machine.nix desktop mode flag (inserts the field if missing).
+# When isDesktop=true AND lite=true on macOS, enables Docker via podman.
+export def set-desktop-mode [value: bool, --path(-p): string] {
+    let target_path = ($path | default (machine-config-path))
+    if not ($target_path | path exists) {
+        error make {
+            msg: $"machine.nix not found at: ($target_path)"
+        }
+    }
+    let content = (open $target_path --raw)
+    let desktop_value = (if $value { "true" } else { "false" })
+    let desktop_line = $"  isDesktop = ($desktop_value);"
+    let updated = if ($content | str contains "isDesktop =") {
+        $content | str replace --regex '(?m)^\s*isDesktop\s*=\s*(true|false);\s*$' $desktop_line
+    } else {
+        let with_desktop = $"\n  # Desktop machine — enables Docker via podman on lite macOS\n($desktop_line)\n}"
+        $content | str replace --regex '\n\}\s*$' $with_desktop
+    }
+    $updated | save -f $target_path
+}
 # Set the machine.nix lite mode flag (inserts the field if missing).
 export def set-lite-mode [value: bool, --path(-p): string] {
     let target_path = ($path | default (machine-config-path))
@@ -69,10 +89,13 @@ export def parse-machine-config [] {
     } catch { "" }
     # lite is optional — older machine.nix files may not have it
     let lite = try { (($content | parse --regex 'lite\s*=\s*(true|false);' | get capture0.0) == "true") } catch { false }
+    # isDesktop is optional — older machine.nix files may not have it
+    let isDesktop = try { (($content | parse --regex 'isDesktop\s*=\s*(true|false);' | get capture0.0) == "true") } catch { false }
     {
         username: $username
         system: $system
         hostname: $hostname
         lite: $lite
+        isDesktop: $isDesktop
     }
 }

--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -109,6 +109,8 @@ def main [
     --brew          # With --update on macOS, also run `brew upgrade --cask --greedy` (slow)
     --lite          # Set machine.nix default to lite mode (skip GUI-heavy apps)
     --no-lite       # Set machine.nix default to full mode (include GUI-heavy apps)
+    --desktop       # Set machine.nix isDesktop = true (enable Docker via podman on macOS)
+    --no-desktop    # Set machine.nix isDesktop = false
 ] {
     let nix_config = (nix_config config-dir)
     let machine_config = $"($nix_config)/machine.nix"
@@ -116,6 +118,11 @@ def main [
 
     if $lite and $no_lite {
         err "Cannot use both --lite and --no-lite"
+        exit 1
+    }
+
+    if $desktop and $no_desktop {
+        err "Cannot use both --desktop and --no-desktop"
         exit 1
     }
 
@@ -198,6 +205,15 @@ def main [
         success "Updated machine.nix default: lite = false"
     }
 
+    # Persist desktop mode choice into machine.nix when explicitly requested.
+    if $desktop {
+        nix_config set-desktop-mode true
+        success "Updated machine.nix default: isDesktop = true"
+    } else if $no_desktop {
+        nix_config set-desktop-mode false
+        success "Updated machine.nix default: isDesktop = false"
+    }
+
     # Show current configuration
     info $"Reading machine configuration from: ($machine_config)"
     let config = (nix_config parse-machine-config)
@@ -212,6 +228,7 @@ def main [
     print $"  Username: ($config.username)"
     print $"  System: ($config.system)"
     print $"  Lite: ($config.lite)"
+    print $"  Desktop: ($config.isDesktop)"
     print ""
 
     # Rebuild must work even when the user's shell has not loaded Nix yet.


### PR DESCRIPTION
## Summary

Wire the existing (but unused) `isDesktop` field from `machine.nix` through the Nix config stack so that **lite macOS desktops** (e.g. Mac Mini) get Docker compatibility via podman — without changing the `--lite` setup.

### How it works

When `isDesktop=true` **AND** `lite=true` **AND** platform=darwin:

- `docker` wrapper script → calls `podman`
- `docker-compose` wrapper script → calls `podman-compose`
- `podman-compose` package installed (enables `podman compose`)
- Activation script runs `podman machine init` on first rebuild (idempotent)

The `--lite` setup remains unchanged: OrbStack and podman-desktop casks are still only included in non-lite mode.

### CLI changes

- `rebuild --desktop` / `rebuild --no-desktop` — toggle `isDesktop` in `machine.nix`
- Config summary now shows `Desktop:` status

### Files changed

| File | Change |
|---|---|
| `flake.nix` | Thread `isDesktop` through module args, `extraSpecialArgs`, both output configs |
| `darwin.nix` | Accept `isDesktop` parameter |
| `home.nix` | Add conditional packages + activation script gated on `isDesktop && lite && isDarwin` |
| `machine.nix.example` | Document `isDesktop` field |
| `nix_config.nu` | Parse `isDesktop`; add `set-desktop-mode` command |
| `rebuild` | Add `--desktop`/`--no-desktop` flags; display `Desktop:` in summary |

### Post-rebuild

After `rebuild --desktop`, run once:
```sh
podman machine start
```

Then all existing nushell aliases (`dk`, `dkc`, `dkcu`, etc.) work transparently via the `docker` → `podman` wrapper.