### PR TITLE
feat: enforce minimum macOS version and add --update-os rebuild flag

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -377,5 +377,35 @@
       StandardHideDesktopIcons = false;
       StandardHideWidgets = false;
     };
+
+    # Automatically install macOS software updates (security patches, OS upgrades).
+    # This enables System Preferences → Software Update → "Automatically keep
+    # my Mac up to date" and installs available updates automatically.
+    SoftwareUpdate.AutomaticallyInstallMacOSUpdates = true;
   };
+
+  # Enforce minimum macOS version during system activation.
+  # Prints a warning if the running macOS version is below the minimum.
+  # Security patches are critical — running an outdated macOS version leaves
+  # the system vulnerable. Set minimumVersion to the oldest supported release.
+  system.activationScripts.minimumMacOSVersion.text =
+    let
+      minimumVersion = "15.0"; # macOS Sequoia 15.0+
+    in
+    ''
+      #!/bin/sh
+      CURRENT=$(/usr/bin/sw_vers -productVersion)
+      MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+      MINOR=$(echo "$CURRENT" | cut -d. -f2)
+      REQ_MAJOR=$(echo "${minimumVersion}" | cut -d. -f1)
+      REQ_MINOR=$(echo "${minimumVersion}" | cut -d. -f2)
+      if [ "$MAJOR" -lt "$REQ_MAJOR" ] || { [ "$MAJOR" -eq "$REQ_MAJOR" ] && [ "$MINOR" -lt "$REQ_MINOR" ]; }; then
+        echo >&2 ""
+        echo >&2 "⚠️  WARNING: macOS version $CURRENT is below minimum ${minimumVersion}"
+        echo >&2 "    macOS Sequoia 15.0+ is required for security compliance."
+        echo >&2 "    Run: softwareupdate --install --all"
+        echo >&2 "    Or: rebuild --update-os"
+        echo >&2 ""
+      fi
+    '';
 }

--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -113,6 +113,7 @@ def main [
     --no-desktop    # Set machine.nix isDesktop = false
     --latest        # Update dotfiles repo to the latest version before rebuilding
     --force         # With --latest, force-reset to latest even with local changes
+    --update-os     # Install all available macOS software updates before rebuilding (slow)
 ] {
     if $force and not $latest {
         err "--force requires --latest"
@@ -349,6 +350,23 @@ def main [
     let flake_dir = (nix_config flake-dir)
 
     let os = (platform os)
+
+    # Install all available macOS software updates before rebuilding.
+    # This is a no-op on Linux. On macOS it runs `softwareupdate --install --all`
+    # which includes security patches and OS version upgrades. Requires sudo.
+    if $update_os and $os == "darwin" {
+        info "Installing macOS software updates (this may take a while)..."
+        ensure_darwin_sudo_session
+        let os_update_ok = run_with_darwin_sudo_keepalive "softwareupdate --install --all"
+        if $os_update_ok {
+            success "macOS software updates installed"
+        } else {
+            warn "macOS software update failed or no updates available (continuing)"
+        }
+        print ""
+    } else if $update_os and $os != "darwin" {
+        warn "--update-os is only supported on macOS"
+    }
 
     # Update flake inputs (only when --update is passed)
     if $update {


### PR DESCRIPTION
## Summary

Three complementary mechanisms to keep macOS up to date for security:

### 1️⃣ Declarative auto-update (darwin.nix)
```nix
system.defaults.SoftwareUpdate.AutomaticallyInstallMacOSUpdates = true;
```
Enables System Preferences → Software Update → "Automatically keep my Mac up to date". This installs security patches and OS upgrades automatically.

### 2️⃣ Minimum version warning (darwin.nix activation script)
Added `system.activationScripts.minimumMacOSVersion` that checks the running macOS version against a minimum (currently macOS Sequoia 15.0+) during every rebuild. Prints a prominent warning if below threshold:

```
⚠️  WARNING: macOS version 14.5 is below minimum 15.0
    macOS Sequoia 15.0+ is required for security compliance.
    Run: softwareupdate --install --all
    Or: rebuild --update-os
```

The minimum version is a Nix `let` binding, easy to bump:
```nix
minimumVersion = "15.0"; # macOS Sequoia 15.0+
```

### 3️⃣ `rebuild --update-os` flag
New flag that runs `softwareupdate --install --all` on macOS before rebuilding. This installs all available OS updates including security patches and version upgrades. Uses the existing darwin sudo keepalive mechanism. No-op on Linux.

```sh
rebuild --update-os           # Install macOS updates, then rebuild
rebuild --update --update-os  # Update flake + macOS, then rebuild
rebuild --update --brew --update-os  # Full update everything
```

### Files changed
| File | Change |
|---|---|
| `darwin.nix` | Add `SoftwareUpdate.AutomaticallyInstallMacOSUpdates = true`; add minimum version activation script |
| `rebuild` | Add `--update-os` flag |