### PR TITLE
feat: set minimum macOS to 26.5 and rename --update-os to --rebuild-os

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -390,7 +390,7 @@
   # the system vulnerable. Set minimumVersion to the oldest supported release.
   system.activationScripts.minimumMacOSVersion.text =
     let
-      minimumVersion = "15.0"; # macOS Sequoia 15.0+
+      minimumVersion = "26.5"; # macOS 26.5+
     in
     ''
       #!/bin/sh
@@ -402,9 +402,8 @@
       if [ "$MAJOR" -lt "$REQ_MAJOR" ] || { [ "$MAJOR" -eq "$REQ_MAJOR" ] && [ "$MINOR" -lt "$REQ_MINOR" ]; }; then
         echo >&2 ""
         echo >&2 "⚠️  WARNING: macOS version $CURRENT is below minimum ${minimumVersion}"
-        echo >&2 "    macOS Sequoia 15.0+ is required for security compliance."
-        echo >&2 "    Run: softwareupdate --install --all"
-        echo >&2 "    Or: rebuild --update-os"
+        echo >&2 "    macOS 26.5+ is required for security compliance."
+        echo >&2 "    Run: rebuild --update-os"
         echo >&2 ""
       fi
     '';

--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -113,7 +113,7 @@ def main [
     --no-desktop    # Set machine.nix isDesktop = false
     --latest        # Update dotfiles repo to the latest version before rebuilding
     --force         # With --latest, force-reset to latest even with local changes
-    --update-os     # Install all available macOS software updates before rebuilding (slow)
+    --rebuild-os   # Install all available macOS software updates before rebuilding (slow)
 ] {
     if $force and not $latest {
         err "--force requires --latest"
@@ -354,7 +354,7 @@ def main [
     # Install all available macOS software updates before rebuilding.
     # This is a no-op on Linux. On macOS it runs `softwareupdate --install --all`
     # which includes security patches and OS version upgrades. Requires sudo.
-    if $update_os and $os == "darwin" {
+    if $rebuild_os and $os == "darwin" {
         info "Installing macOS software updates (this may take a while)..."
         ensure_darwin_sudo_session
         let os_update_ok = run_with_darwin_sudo_keepalive "softwareupdate --install --all"
@@ -364,8 +364,8 @@ def main [
             warn "macOS software update failed or no updates available (continuing)"
         }
         print ""
-    } else if $update_os and $os != "darwin" {
-        warn "--update-os is only supported on macOS"
+    } else if $rebuild_os and $os != "darwin" {
+        warn "--rebuild-os is only supported on macOS"
     }
 
     # Update flake inputs (only when --update is passed)


### PR DESCRIPTION
## Changes

- Set minimum macOS version from 15.0 to **26.5** (macOS 26 Tahoe)
- Rename `rebuild --update-os` → `rebuild --rebuild-os` for naming consistency
- Simplify activation script suggestion to just `rebuild --rebuild-os`

### Activation warning (if below 26.5)
```
⚠️  WARNING: macOS version 26.3 is below minimum 26.5
    macOS 26.5+ is required for security compliance.
    Run: rebuild --rebuild-os
```