### PR TITLE
fix: update ifiokjr-nixpkgs to fix op hash mismatch

### DIFF
--- a/Configs/nix/.config/nix/flake.lock
+++ b/Configs/nix/.config/nix/flake.lock
@@ -132,11 +132,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779013036,
-        "narHash": "sha256-JeqGyjub5VfCEGJI2UZLI00eejMIcj1TX4s6chfpwko=",
+        "lastModified": 1779037297,
+        "narHash": "sha256-SiuHa7Sp0eDcoSOjG61Q2dbBeKu5jeF6XaSRuvM39Vk=",
         "owner": "ifiokjr",
         "repo": "nixpkgs",
-        "rev": "d7427f997e6ae19cca87458fa81b66b298c487dd",
+        "rev": "5305cc970c99c1db60e1d7c9eda39b4ca0fe5c06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

The `ci-nix` workflow was failing on the `main` branch due to a **hash mismatch** in the 1Password CLI (`op`) package v2.35.0-beta.01:

```
error: hash mismatch in fixed-output derivation:
  specified: sha256-oNzlRzPPMxc3oA4UkSV/VohqzoLAo9SBxcwzqdcwW84=
     got:    sha256-R1O+u38bEqmAuOhyvm+Zb+xSYi32ySbXZW+EL33UJW8=
```

1Password republished the beta binaries with different content, invalidating the previously-pinned hashes for both Linux platforms.

## Fix

1. Updated the `op` package hashes in [ifiokjr/nixpkgs#52](https://github.com/ifiokjr/nixpkgs/pull/52) (already merged)
2. Updated the `ifiokjr-nixpkgs` flake input in this repo to point to the fixed revision (`5305cc9`)

### Hash changes in ifiokjr/nixpkgs
| Platform | Old hash | New hash |
|---|---|---|
| aarch64-linux | `sha256-HlmNAnHe...` | `sha256-DH2Ze6AV...` |
| x86_64-linux | `sha256-oNzlRzPP...` | `sha256-R1O+u38b...` |
| aarch64-darwin | unchanged | unchanged |