### PR TITLE
feat: add Tailscale cask to lite desktop macOS

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -153,6 +153,7 @@
       ++ lib.optionals (isDesktop && lite) [
         # Essential desktop apps for lite macOS machines
         "ghostty" # Terminal emulator — needed even in lite mode on desktop machines
+        "tailscale" # Mesh VPN — background daemon for always-on connectivity
       ];
   };
 


### PR DESCRIPTION
Adds the Tailscale Homebrew cask to the `isDesktop && lite` section in darwin.nix, alongside ghostty.

Without the cask, Tailscale on macOS has no persistent daemon — `tailscaled` must be started manually. The cask provides the system extension that auto-starts the daemon at boot. The `services.tailscale.enable = true` nix-darwin config is already in place.