### PR TITLE
fix: make pnpm:global:sync compatible with pnpm v11

### DIFF
--- a/Configs/scripts/.local/bin/pnpm:global:sync
+++ b/Configs/scripts/.local/bin/pnpm:global:sync
@@ -61,7 +61,7 @@ sanitize_manifest_dependencies_meta() {
 
   if (
     cd "$manifest_dir"
-    pnpm node - "$manifest_path" <<'NODE'
+    node - "$manifest_path" <<'NODE'
 const fs = require('fs');
 const manifestPath = process.argv[2];
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
@@ -214,14 +214,20 @@ for manifest in package.json pnpm-lock.yaml pnpm-workspace.yaml; do
   fi
 done
 
-INSTALL_ARGS=(install -g)
+INSTALL_ARGS=(install -g --ignore-scripts)
 if [ -f "$SOURCE_DIR/pnpm-lock.yaml" ]; then
   INSTALL_ARGS+=(--frozen-lockfile)
 fi
 
-if ! pnpm "${INSTALL_ARGS[@]}"; then
-  fail "pnpm global install failed"
-  exit $?
+if ! pnpm "${INSTALL_ARGS[@]}" 2>/dev/null; then
+  # pnpm v11 may fail with --frozen-lockfile if lockfile needs migration.
+  # Retry without --frozen-lockfile to let pnpm regenerate it.
+  warn "pnpm global install with frozen lockfile failed; retrying without --frozen-lockfile..."
+  rm -f "$SOURCE_DIR/pnpm-lock.yaml" "$GLOBAL_DIR/pnpm-lock.yaml"
+  if ! pnpm install -g --ignore-scripts; then
+    fail "pnpm global install failed"
+    exit $?
+  fi
 fi
 
 if [ "$SANITIZE_MANIFESTS" = true ]; then


### PR DESCRIPTION
## Problem

After upgrading to pnpm v11 (from `extra.pnpm-11`), `pnpm:global:sync` fails with:
- `pnpm node` now triggers `pnpm install` first in v11, which breaks sanitization
- `runDepsStatusCheck` fails because the lockfile from v10 needs migration
- `ERR_PNPM_IGNORED_BUILDS` because v11 requires build script approvals

## Fix

1. **`pnpm node` → `node`**: Use plain Node.js for JSON sanitization instead of pnpm's bundled `node` subcommand, which changed behavior in v11.

2. **Lockfile migration fallback**: If `--frozen-lockfile` install fails, delete the old lockfile and retry without it, letting pnpm v11 regenerate it. Also adds `--ignore-scripts` since global packages don't need build scripts.