### PR TITLE
fix: ensure PNPM_HOME/bin is on PATH for pnpm v11

### DIFF
--- a/Configs/scripts/.local/bin/pnpm:global:sync
+++ b/Configs/scripts/.local/bin/pnpm:global:sync
@@ -167,7 +167,11 @@ if [ -z "${PNPM_HOME:-}" ]; then
   export PNPM_HOME
 fi
 
-mkdir -p "$PNPM_HOME"
+mkdir -p "$PNPM_HOME" "$PNPM_HOME/bin"
+case ":$PATH:" in
+  *":$PNPM_HOME/bin:"*) ;;
+  *) export PATH="$PNPM_HOME/bin:$PATH" ;;
+esac
 case ":$PATH:" in
   *":$PNPM_HOME:"*) ;;
   *) export PATH="$PNPM_HOME:$PATH" ;;


### PR DESCRIPTION
pnpm v11 requires $PNPM_HOME/bin on PATH. The sync script only added $PNPM_HOME.