### PR TITLE
feat: manage pnpm globals as a project

### DIFF
--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -94,6 +94,7 @@ let path_prepend = [
     $"($env.HOME)/.local/bin"
     $"($env.HOME)/.cargo/bin"
     $"($env.HOME)/.shorebird/bin"
+    $"($env.HOME)/.config/pnpm-global/node_modules/.bin"
     $env.PNPM_HOME
     $"($env.HOME)/.local/share/solana/install/active_release/bin"
     $"($env.HOME)/fvm/default/bin"

--- a/Configs/pnpm/.config/pnpm-global/package.json
+++ b/Configs/pnpm/.config/pnpm-global/package.json
@@ -1,4 +1,7 @@
 {
+	"name": "ifiokjr-managed-pnpm-global-packages",
+	"private": true,
+	"packageManager": "pnpm@11.0.4",
 	"dependencies": {
 		"@anthropic-ai/claude-code": "^2.1.143",
 		"@devcontainers/cli": "^0.87.0",

--- a/Configs/pnpm/.config/pnpm-global/pnpm-lock.yaml
+++ b/Configs/pnpm/.config/pnpm-global/pnpm-lock.yaml
@@ -56,6 +56,7 @@ importers:
       vscode-langservers-extracted:
         specifier: ^4.10.0
         version: 4.10.0
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
+++ b/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
@@ -32,10 +32,11 @@ export def diff-nix-closures [old_path: string, new_path: string] {
 # ─────────────────────────────────────────────────────────────────────────────
 # pnpm globals
 # ─────────────────────────────────────────────────────────────────────────────
-# Return a list of {name, version} records for globally installed pnpm packages.
+# Return a list of {name, version} records for managed pnpm global project packages.
 export def capture-pnpm-globals [] {
     if (which pnpm | is-empty) { return null }
-    let result = (^pnpm list -g --json | complete)
+    if not ($"($env.HOME)/.config/pnpm-global/package.json" | path exists) { return null }
+    let result = (^bash -lc 'cd "$HOME/.config/pnpm-global" && pnpm list --json' | complete)
     if ($result.exit_code != 0) { return null }
     let parsed = try {
         $result.stdout | from json

--- a/Configs/scripts/.local/bin/pnpm:global:add
+++ b/Configs/scripts/.local/bin/pnpm:global:add
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  cat >&2 <<'USAGE'
+Usage: pnpm:global:add <pkg...>
+
+Add packages to the Tuckr-managed pnpm global project at ~/.config/pnpm-global.
+USAGE
+  exit 1
+fi
+
+PROJECT_DIR="$HOME/.config/pnpm-global"
+mkdir -p "$PROJECT_DIR"
+cd "$PROJECT_DIR"
+
+pnpm add "$@"
+
+cat <<'NEXT'
+
+Added package(s) to the managed pnpm global project.
+Review and commit the updated files in Configs/pnpm/.config/pnpm-global.
+NEXT

--- a/Configs/scripts/.local/bin/pnpm:global:list
+++ b/Configs/scripts/.local/bin/pnpm:global:list
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$HOME/.config/pnpm-global"
+cd "$PROJECT_DIR"
+
+pnpm list "$@"

--- a/Configs/scripts/.local/bin/pnpm:global:remove
+++ b/Configs/scripts/.local/bin/pnpm:global:remove
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  cat >&2 <<'USAGE'
+Usage: pnpm:global:remove <pkg...>
+
+Remove packages from the Tuckr-managed pnpm global project at ~/.config/pnpm-global.
+USAGE
+  exit 1
+fi
+
+PROJECT_DIR="$HOME/.config/pnpm-global"
+cd "$PROJECT_DIR"
+
+pnpm remove "$@"
+
+cat <<'NEXT'
+
+Removed package(s) from the managed pnpm global project.
+Review and commit the updated files in Configs/pnpm/.config/pnpm-global.
+NEXT

--- a/Configs/scripts/.local/bin/pnpm:global:sync
+++ b/Configs/scripts/.local/bin/pnpm:global:sync
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sync global pnpm package manifests from ~/.config/pnpm-global into the
-# active global pnpm directory (resolved dynamically via `pnpm root -g`).
+# Install managed pnpm CLI tools from the Tuckr-managed project at
+# ~/.config/pnpm-global. Binaries are exposed by putting that project's
+# node_modules/.bin directory on PATH.
 
 QUIET=false
 NO_FAIL=false
@@ -18,6 +19,9 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
       cat <<'USAGE'
 Usage: pnpm:global:sync [--quiet] [--no-fail]
+
+Install managed CLI packages from ~/.config/pnpm-global using normal project
+pnpm install semantics.
 
 Options:
   --quiet    Suppress info output
@@ -51,88 +55,6 @@ fail() {
   return 1
 }
 
-sanitize_manifest_dependencies_meta() {
-  local manifest_path="$1"
-  local manifest_dir
-
-  [ -f "$manifest_path" ] || return 0
-
-  manifest_dir="$(dirname "$manifest_path")"
-
-  if (
-    cd "$manifest_dir"
-    node - "$manifest_path" <<'NODE'
-const fs = require('fs');
-const manifestPath = process.argv[2];
-const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-
-if (!Object.prototype.hasOwnProperty.call(manifest, 'dependenciesMeta')) {
-  process.exit(10);
-}
-
-delete manifest.dependenciesMeta;
-fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, '\t')}\n`);
-NODE
-  ); then
-    info "Removed pnpm-generated dependenciesMeta from $manifest_path"
-  else
-    local status=$?
-    case "$status" in
-      10) ;;
-      *)
-        fail "Failed to sanitize $manifest_path"
-        return $?
-        ;;
-    esac
-  fi
-}
-
-sanitize_lockfile_dependencies_meta() {
-  local lockfile_path="$1"
-
-  [ -f "$lockfile_path" ] || return 0
-
-  local tmpfile
-  tmpfile="$(mktemp)"
-
-  if awk '
-    BEGIN {
-      skipping = 0
-      removed = 0
-    }
-    /^    dependenciesMeta:$/ {
-      skipping = 1
-      removed = 1
-      next
-    }
-    skipping && (/^    [^ ]/ || /^[^ ]/) {
-      skipping = 0
-    }
-    !skipping {
-      print
-    }
-    END {
-      if (!removed) exit 10
-    }
-  ' "$lockfile_path" > "$tmpfile"; then
-    mv "$tmpfile" "$lockfile_path"
-    info "Removed pnpm-generated dependenciesMeta from $lockfile_path"
-  else
-    local status=$?
-    rm -f "$tmpfile"
-    case "$status" in
-      10) ;;
-      *)
-        fail "Failed to sanitize $lockfile_path"
-        return $?
-        ;;
-    esac
-  fi
-}
-
-# Home Manager activation hooks may run in a non-login shell where PATH does
-# not include nix profile bins yet. Ensure common nix profile locations exist
-# on PATH before checking for pnpm.
 user_name="${USER:-}"
 if [ -z "$user_name" ]; then
   user_name="$(id -un 2>/dev/null || true)"
@@ -154,101 +76,31 @@ done
 unset _p user_name profile_paths
 
 if ! command -v pnpm >/dev/null 2>&1; then
-  fail "pnpm is not installed; skipping pnpm global sync"
+  fail "pnpm is not installed; skipping managed pnpm global sync"
   exit $?
 fi
 
-if [ -z "${PNPM_HOME:-}" ]; then
-  if [ "$(uname -s)" = "Darwin" ]; then
-    PNPM_HOME="$HOME/Library/pnpm"
-  else
-    PNPM_HOME="$HOME/.local/share/pnpm"
-  fi
-  export PNPM_HOME
-fi
-
-mkdir -p "$PNPM_HOME" "$PNPM_HOME/bin"
-case ":$PATH:" in
-  *":$PNPM_HOME/bin:"*) ;;
-  *) export PATH="$PNPM_HOME/bin:$PATH" ;;
-esac
-case ":$PATH:" in
-  *":$PNPM_HOME:"*) ;;
-  *) export PATH="$PNPM_HOME:$PATH" ;;
-esac
-
-SANITIZE_MANIFESTS=true
-if ! command -v node >/dev/null 2>&1; then
-  SANITIZE_MANIFESTS=false
-  warn "node is not installed; skipping pnpm global manifest sanitization"
-fi
-
-SOURCE_DIR="$HOME/.config/pnpm-global"
-if [ ! -f "$SOURCE_DIR/package.json" ]; then
-  info "No $SOURCE_DIR/package.json found; skipping pnpm global sync"
+PROJECT_DIR="$HOME/.config/pnpm-global"
+if [ ! -f "$PROJECT_DIR/package.json" ]; then
+  info "No $PROJECT_DIR/package.json found; skipping managed pnpm global sync"
   exit 0
 fi
 
-# pnpm may add dependenciesMeta.*.node during global installs, which hardcodes
-# a machine-specific Node.js path into the managed manifest and lockfile.
-if [ "$SANITIZE_MANIFESTS" = true ]; then
-  sanitize_manifest_dependencies_meta "$SOURCE_DIR/package.json"
-  sanitize_lockfile_dependencies_meta "$SOURCE_DIR/pnpm-lock.yaml"
+mkdir -p "$PROJECT_DIR"
+cd "$PROJECT_DIR"
+
+if [ -f pnpm-lock.yaml ]; then
+  if pnpm install --frozen-lockfile --ignore-scripts; then
+    info "Managed pnpm global packages synced"
+    exit 0
+  fi
+
+  warn "pnpm install with frozen lockfile failed; retrying without --frozen-lockfile..."
 fi
 
-if ! GLOBAL_ROOT="$(pnpm root -g 2>/dev/null)"; then
-  fail "Failed to resolve pnpm global root with 'pnpm root -g'"
+if ! pnpm install --ignore-scripts; then
+  fail "Managed pnpm global package install failed"
   exit $?
 fi
 
-GLOBAL_DIR="$(dirname "$GLOBAL_ROOT")"
-mkdir -p "$GLOBAL_DIR"
-
-for manifest in package.json pnpm-lock.yaml pnpm-workspace.yaml; do
-  src="$SOURCE_DIR/$manifest"
-  dest="$GLOBAL_DIR/$manifest"
-
-  if [ -f "$src" ]; then
-    rm -f "$dest"
-    ln -sfn "$src" "$dest"
-    info "Linked $dest -> $src"
-  elif [ -L "$dest" ]; then
-    rm -f "$dest"
-    info "Removed stale symlink $dest"
-  fi
-done
-
-mapfile -t GLOBAL_PACKAGE_SPECS < <(
-  node - "$SOURCE_DIR/package.json" <<'NODE'
-const fs = require('fs');
-const manifestPath = process.argv[2];
-const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-const dependencies = manifest.dependencies || {};
-
-for (const [name, version] of Object.entries(dependencies)) {
-  console.log(`${name}@${version}`);
-}
-NODE
-)
-
-if [ "${#GLOBAL_PACKAGE_SPECS[@]}" -eq 0 ]; then
-  info "No managed pnpm global dependencies found"
-  exit 0
-fi
-
-# pnpm v11 no longer supports `pnpm install -g` from a package manifest.
-# Keep the manifest as the source of truth, but install entries via `pnpm add -g`.
-if ! pnpm add -g --ignore-scripts "${GLOBAL_PACKAGE_SPECS[@]}"; then
-  rm -f "$SOURCE_DIR/pnpm-lock.yaml" "$GLOBAL_DIR/pnpm-lock.yaml"
-  if ! pnpm add -g --ignore-scripts "${GLOBAL_PACKAGE_SPECS[@]}"; then
-    fail "pnpm global add failed"
-    exit $?
-  fi
-fi
-
-if [ "$SANITIZE_MANIFESTS" = true ]; then
-  sanitize_manifest_dependencies_meta "$SOURCE_DIR/package.json"
-  sanitize_lockfile_dependencies_meta "$SOURCE_DIR/pnpm-lock.yaml"
-fi
-
-info "pnpm global packages synced"
+info "Managed pnpm global packages synced"

--- a/Configs/scripts/.local/bin/pnpm:global:update
+++ b/Configs/scripts/.local/bin/pnpm:global:update
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$HOME/.config/pnpm-global"
+cd "$PROJECT_DIR"
+
+pnpm update "$@"
+
+cat <<'NEXT'
+
+Updated the managed pnpm global project.
+Review and commit the updated files in Configs/pnpm/.config/pnpm-global.
+NEXT

--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -383,21 +383,21 @@ def main [
         }
         print ""
 
-        # Update pnpm global dependencies to their latest compatible versions
-        if (which pnpm | is-not-empty) {
-            info "Updating pnpm global dependencies..."
+        # Update managed pnpm global project dependencies to their latest compatible versions
+        if (which pnpm:global:update | is-not-empty) {
+            info "Updating managed pnpm global dependencies..."
             let pnpm_ok = try {
-                ^bash -c 'if [ -z "${PNPM_HOME:-}" ]; then if [ "$(uname -s)" = "Darwin" ]; then PNPM_HOME="$HOME/Library/pnpm"; else PNPM_HOME="$HOME/.local/share/pnpm"; fi; fi; mkdir -p "$PNPM_HOME" "$PNPM_HOME/bin"; export PNPM_HOME PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"; pnpm update -g -L'
+                ^pnpm:global:update
                 true
             } catch { false }
             if $pnpm_ok {
-                success "pnpm global dependencies updated"
+                success "Managed pnpm global dependencies updated"
             } else {
-                warn "pnpm global update failed \(continuing\)"
+                warn "Managed pnpm global update failed \(continuing\)"
             }
             print ""
         } else {
-            warn "pnpm not found, skipping global dependency update"
+            warn "pnpm:global:update not found, skipping managed pnpm global dependency update"
         }
 
         if $brew {

--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -387,7 +387,7 @@ def main [
         if (which pnpm:global:update | is-not-empty) {
             info "Updating managed pnpm global dependencies..."
             let pnpm_ok = try {
-                ^pnpm:global:update
+                ^bash -lc 'pnpm:global:update'
                 true
             } catch { false }
             if $pnpm_ok {

--- a/Configs/shell/.config/shell/env.sh
+++ b/Configs/shell/.config/shell/env.sh
@@ -83,6 +83,7 @@ export DIRENV_LOG_FORMAT=""
 for _p in "$HOME/.local/bin" \
 	"$HOME/.cargo/bin" \
 	"$HOME/.shorebird/bin" \
+	"$HOME/.config/pnpm-global/node_modules/.bin" \
 	"$PNPM_HOME" \
 	"$HOME/.local/share/solana/install/active_release/bin" \
 	"$HOME/fvm/default/bin" \

--- a/Hooks/pnpm/post.sh
+++ b/Hooks/pnpm/post.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Sync pnpm global manifests and reconcile global package installs.
+# Install the Tuckr-managed pnpm global project dependencies.
 SYNC_SCRIPT="$HOME/.local/bin/pnpm:global:sync"
 
 # Fallback for partial/manual deployments where scripts group is not linked yet.

--- a/readme.md
+++ b/readme.md
@@ -157,7 +157,8 @@ The setup flow layers metadata on top of Tuckr conventions:
 - `rebuild` - Cross-platform system rebuild (`nh darwin switch` on macOS, `nh home switch` on Linux); successful runs also sync managed global pnpm packages, and `rebuild --update` refreshes `flake.lock` before rebuilding
 - `generate-machine-config` - Auto-detect and generate machine.nix for Nix configuration
 - `update:node` - Update Node.js to latest version using pnpm env
-- `pnpm:global:sync` - Symlink global pnpm manifests and install pinned global packages
+- `pnpm:global:sync` - Install the managed pnpm global project packages
+- `pnpm:global:add/remove/update/list` - Manage packages in the pnpm global project
 - `install:helix:custom` - Build Helix with Steel plugin support
 - `setup:env` - Interactive environment variables setup (API keys, tokens)
 - `ci_check` - Run local CI checks before pushing (formatting, shellcheck, nushell, nix)
@@ -182,9 +183,9 @@ The setup flow layers metadata on top of Tuckr conventions:
 
 #### `pnpm`
 
-**Location:** `Configs/pnpm/.config/pnpm-global/` **Deploys:** `~/.config/pnpm-global/` **Description:** Managed global pnpm manifest (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) for deterministic global package installs on macOS and Linux.
+**Location:** `Configs/pnpm/.config/pnpm-global/` **Deploys:** `~/.config/pnpm-global/` **Description:** Managed pnpm project (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) for deterministic CLI tool installs on macOS and Linux.
 
-**Hook:** `post_pnpm` - Resolves pnpm's active global directory and symlinks/installs the managed global package set.
+**Hook:** `post_pnpm` - Runs `pnpm:global:sync`, which installs the managed project with normal `pnpm install` semantics. Shell startup adds `~/.config/pnpm-global/node_modules/.bin` to PATH.
 
 Pi remains installed through the managed pnpm packages, but `~/.pi/` is intentionally user-managed instead of synced by Tuckr.
 
@@ -548,9 +549,9 @@ Use:
 tuckr set pnpm
 ```
 
-to sync `~/.config/pnpm-global` into pnpm's active global directory (resolved from `pnpm root -g`) and install packages from the committed lockfile.
+to install the Tuckr-managed project at `~/.config/pnpm-global` from the committed lockfile. Shell startup adds `~/.config/pnpm-global/node_modules/.bin` to PATH, so installed CLI binaries are available globally without using pnpm's special global install mode.
 
-The sync script also strips pnpm-generated `dependenciesMeta.*.node` entries from the managed manifest and lockfile, so machine-specific Node.js paths are not committed.
+Use `pnpm:global:add <pkg>`, `pnpm:global:remove <pkg>`, `pnpm:global:update [pkg]`, and `pnpm:global:list` to manage this project intentionally, then commit the resulting `Configs/pnpm/.config/pnpm-global/package.json` and `pnpm-lock.yaml` changes.
 
 Successful `rebuild` runs invoke the same managed sync explicitly, so global CLI packages like Pi stay installed after Nix/home-manager updates.
 


### PR DESCRIPTION
Migrate managed pnpm CLI tools away from pnpm's special global install mode.\n\nChanges:\n- Treat `Configs/pnpm/.config/pnpm-global` as a normal Tuckr-managed pnpm project.\n- `pnpm:global:sync` now runs normal `pnpm install` in `~/.config/pnpm-global`.\n- Add `pnpm:global:add`, `pnpm:global:remove`, `pnpm:global:update`, and `pnpm:global:list` helper commands.\n- Add `~/.config/pnpm-global/node_modules/.bin` to shell and Nushell PATH.\n- Update rebuild/version tracking/docs to use the managed project model.