### PR TITLE
fix: install managed pnpm globals outside tuckr config

### DIFF
--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -94,7 +94,7 @@ let path_prepend = [
     $"($env.HOME)/.local/bin"
     $"($env.HOME)/.cargo/bin"
     $"($env.HOME)/.shorebird/bin"
-    $"($env.HOME)/.config/pnpm-global/node_modules/.bin"
+    $"($env.XDG_DATA_HOME? | default ($env.HOME | path join '.local/share'))/pnpm-global/node_modules/.bin"
     $env.PNPM_HOME
     $"($env.HOME)/.local/share/solana/install/active_release/bin"
     $"($env.HOME)/fvm/default/bin"

--- a/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
+++ b/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
@@ -35,8 +35,9 @@ export def diff-nix-closures [old_path: string, new_path: string] {
 # Return a list of {name, version} records for managed pnpm global project packages.
 export def capture-pnpm-globals [] {
     if (which pnpm | is-empty) { return null }
-    if not ($"($env.HOME)/.config/pnpm-global/package.json" | path exists) { return null }
-    let result = (^bash -lc 'cd "$HOME/.config/pnpm-global" && pnpm list --json' | complete)
+    let runtime_dir = ($env.XDG_DATA_HOME? | default ($env.HOME | path join ".local/share") | path join "pnpm-global")
+    if not ($runtime_dir | path join "package.json" | path exists) { return null }
+    let result = (^bash -lc 'cd "${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global" && pnpm list --json' | complete)
     if ($result.exit_code != 0) { return null }
     let parsed = try {
         $result.stdout | from json

--- a/Configs/scripts/.local/bin/pnpm:global:add
+++ b/Configs/scripts/.local/bin/pnpm:global:add
@@ -5,19 +5,20 @@ if [ "$#" -eq 0 ]; then
   cat >&2 <<'USAGE'
 Usage: pnpm:global:add <pkg...>
 
-Add packages to the Tuckr-managed pnpm global project at ~/.config/pnpm-global.
+Add packages to the Tuckr-managed pnpm global manifests at ~/.config/pnpm-global.
 USAGE
   exit 1
 fi
 
-PROJECT_DIR="$HOME/.config/pnpm-global"
-mkdir -p "$PROJECT_DIR"
-cd "$PROJECT_DIR"
+SOURCE_DIR="$HOME/.config/pnpm-global"
+mkdir -p "$SOURCE_DIR"
+cd "$SOURCE_DIR"
 
-pnpm add "$@"
+pnpm add --lockfile-only "$@"
+pnpm:global:sync
 
 cat <<'NEXT'
 
-Added package(s) to the managed pnpm global project.
+Added package(s) to the managed pnpm global manifests.
 Review and commit the updated files in Configs/pnpm/.config/pnpm-global.
 NEXT

--- a/Configs/scripts/.local/bin/pnpm:global:list
+++ b/Configs/scripts/.local/bin/pnpm:global:list
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_DIR="$HOME/.config/pnpm-global"
-cd "$PROJECT_DIR"
+RUNTIME_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global"
+cd "$RUNTIME_DIR"
 
 pnpm list "$@"

--- a/Configs/scripts/.local/bin/pnpm:global:remove
+++ b/Configs/scripts/.local/bin/pnpm:global:remove
@@ -5,18 +5,19 @@ if [ "$#" -eq 0 ]; then
   cat >&2 <<'USAGE'
 Usage: pnpm:global:remove <pkg...>
 
-Remove packages from the Tuckr-managed pnpm global project at ~/.config/pnpm-global.
+Remove packages from the Tuckr-managed pnpm global manifests at ~/.config/pnpm-global.
 USAGE
   exit 1
 fi
 
-PROJECT_DIR="$HOME/.config/pnpm-global"
-cd "$PROJECT_DIR"
+SOURCE_DIR="$HOME/.config/pnpm-global"
+cd "$SOURCE_DIR"
 
-pnpm remove "$@"
+pnpm remove --lockfile-only "$@"
+pnpm:global:sync
 
 cat <<'NEXT'
 
-Removed package(s) from the managed pnpm global project.
+Removed package(s) from the managed pnpm global manifests.
 Review and commit the updated files in Configs/pnpm/.config/pnpm-global.
 NEXT

--- a/Configs/scripts/.local/bin/pnpm:global:sync
+++ b/Configs/scripts/.local/bin/pnpm:global:sync
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install managed pnpm CLI tools from the Tuckr-managed project at
-# ~/.config/pnpm-global. Binaries are exposed by putting that project's
-# node_modules/.bin directory on PATH.
+# Install managed pnpm CLI tools from Tuckr-managed manifests at
+# ~/.config/pnpm-global into a runtime project outside the Tuckr group. This
+# keeps generated node_modules out of dotfiles while still letting git pull
+# update the managed package.json and lockfile.
 
 QUIET=false
 NO_FAIL=false
@@ -20,8 +21,8 @@ while [ "$#" -gt 0 ]; do
       cat <<'USAGE'
 Usage: pnpm:global:sync [--quiet] [--no-fail]
 
-Install managed CLI packages from ~/.config/pnpm-global using normal project
-pnpm install semantics.
+Install managed CLI packages from ~/.config/pnpm-global into the runtime
+project at ~/.local/share/pnpm-global.
 
 Options:
   --quiet    Suppress info output
@@ -80,14 +81,29 @@ if ! command -v pnpm >/dev/null 2>&1; then
   exit $?
 fi
 
-PROJECT_DIR="$HOME/.config/pnpm-global"
-if [ ! -f "$PROJECT_DIR/package.json" ]; then
-  info "No $PROJECT_DIR/package.json found; skipping managed pnpm global sync"
+SOURCE_DIR="$HOME/.config/pnpm-global"
+RUNTIME_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global"
+
+if [ ! -f "$SOURCE_DIR/package.json" ]; then
+  info "No $SOURCE_DIR/package.json found; skipping managed pnpm global sync"
   exit 0
 fi
 
-mkdir -p "$PROJECT_DIR"
-cd "$PROJECT_DIR"
+mkdir -p "$RUNTIME_DIR"
+
+for manifest in package.json pnpm-lock.yaml pnpm-workspace.yaml; do
+  src="$SOURCE_DIR/$manifest"
+  dest="$RUNTIME_DIR/$manifest"
+
+  if [ -f "$src" ]; then
+    rm -f "$dest"
+    ln -s "$src" "$dest"
+  elif [ -L "$dest" ]; then
+    rm -f "$dest"
+  fi
+done
+
+cd "$RUNTIME_DIR"
 
 if [ -f pnpm-lock.yaml ]; then
   if pnpm install --frozen-lockfile --ignore-scripts; then

--- a/Configs/scripts/.local/bin/pnpm:global:update
+++ b/Configs/scripts/.local/bin/pnpm:global:update
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PROJECT_DIR="$HOME/.config/pnpm-global"
-cd "$PROJECT_DIR"
+SOURCE_DIR="$HOME/.config/pnpm-global"
+cd "$SOURCE_DIR"
 
-pnpm update "$@"
+pnpm update --lockfile-only "$@"
+pnpm:global:sync
 
 cat <<'NEXT'
 
-Updated the managed pnpm global project.
+Updated the managed pnpm global manifests.
 Review and commit the updated files in Configs/pnpm/.config/pnpm-global.
 NEXT

--- a/Configs/shell/.config/shell/env.sh
+++ b/Configs/shell/.config/shell/env.sh
@@ -83,7 +83,7 @@ export DIRENV_LOG_FORMAT=""
 for _p in "$HOME/.local/bin" \
 	"$HOME/.cargo/bin" \
 	"$HOME/.shorebird/bin" \
-	"$HOME/.config/pnpm-global/node_modules/.bin" \
+	"${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global/node_modules/.bin" \
 	"$PNPM_HOME" \
 	"$HOME/.local/share/solana/install/active_release/bin" \
 	"$HOME/fvm/default/bin" \

--- a/readme.md
+++ b/readme.md
@@ -185,7 +185,7 @@ The setup flow layers metadata on top of Tuckr conventions:
 
 **Location:** `Configs/pnpm/.config/pnpm-global/` **Deploys:** `~/.config/pnpm-global/` **Description:** Managed pnpm project (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) for deterministic CLI tool installs on macOS and Linux.
 
-**Hook:** `post_pnpm` - Runs `pnpm:global:sync`, which installs the managed project with normal `pnpm install` semantics. Shell startup adds `~/.config/pnpm-global/node_modules/.bin` to PATH.
+**Hook:** `post_pnpm` - Runs `pnpm:global:sync`, which links the managed manifests into `~/.local/share/pnpm-global` and installs there with normal `pnpm install` semantics. Shell startup adds `~/.local/share/pnpm-global/node_modules/.bin` to PATH.
 
 Pi remains installed through the managed pnpm packages, but `~/.pi/` is intentionally user-managed instead of synced by Tuckr.
 
@@ -549,7 +549,7 @@ Use:
 tuckr set pnpm
 ```
 
-to install the Tuckr-managed project at `~/.config/pnpm-global` from the committed lockfile. Shell startup adds `~/.config/pnpm-global/node_modules/.bin` to PATH, so installed CLI binaries are available globally without using pnpm's special global install mode.
+to install the Tuckr-managed manifests from `~/.config/pnpm-global` into the runtime project at `~/.local/share/pnpm-global` from the committed lockfile. Shell startup adds `~/.local/share/pnpm-global/node_modules/.bin` to PATH, so installed CLI binaries are available globally without using pnpm's special global install mode or putting generated `node_modules` inside the Tuckr group.
 
 Use `pnpm:global:add <pkg>`, `pnpm:global:remove <pkg>`, `pnpm:global:update [pkg]`, and `pnpm:global:list` to manage this project intentionally, then commit the resulting `Configs/pnpm/.config/pnpm-global/package.json` and `pnpm-lock.yaml` changes.
 


### PR DESCRIPTION
Fixes Tuckr trying to manage generated pnpm node_modules symlinks.\n\nThe managed manifests remain in the Tuckr-managed group at `~/.config/pnpm-global`, but `pnpm:global:sync` now links those manifests into `~/.local/share/pnpm-global` and runs `pnpm install` there. PATH now points at the runtime project's `node_modules/.bin`.\n\nThis keeps `node_modules` out of the Tuckr source tree while preserving git-pull-driven manifest updates.