### PR TITLE
fix: update ifiokjr-nixpkgs to include secretspec package

### DIFF
--- a/Configs/nix/.config/nix/flake.lock
+++ b/Configs/nix/.config/nix/flake.lock
@@ -132,11 +132,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779041885,
-        "narHash": "sha256-QBaSPZq/NpNxQLg1nc5+K1aNSmxgFY7XOP7bSDpY7kU=",
+        "lastModified": 1779082500,
+        "narHash": "sha256-x8NO3074jTmR+1gr7c0KcEi/r4SBhERVEjschtTI2Os=",
         "owner": "ifiokjr",
         "repo": "nixpkgs",
-        "rev": "4318c2234d57ae82f235e54cf5339076e14eabda",
+        "rev": "e09143f1656e86fa41870da9c2bf8abb9da25911",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

Rebuilding with `rebuild --latest --force` fails with:

```
error: attribute 'secretspec' missing
at home.nix:68:7:
    67|       rustup
    68|       extra.secretspec
       |       ^
```

The `home.nix` references `extra.secretspec` but the pinned `ifiokjr-nixpkgs` revision (`4318c22`) didn't include the `secretspec` package yet.

## Fix

Update `ifiokjr-nixpkgs` flake input from `4318c22` → `e09143f` which includes `secretspec`, `herdr`, and other recently-added packages.