### PR TITLE
fix: use pmset instead of nix-darwin power.sleep for alwaysOn

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -438,12 +438,11 @@
   # that module uses `systemsetup`, which doesn't persist settings across
   # reboots on Apple Silicon. Similarly, system.defaults.screensaver has
   # known reliability issues (nix-darwin #908, #1207).
-  system.activationScripts.alwaysOn =
-    lib.optionalString (alwaysOn && pkgs.stdenv.isDarwin) ''
-      echo "==> Configuring always-on power management (pmset)..."
-      /usr/sbin/pmset -a sleep 0 displaysleep 10 disksleep 0
-      echo "==> Enabling screensaver password lock..."
-      /usr/bin/defaults -currentHost write com.apple.screensaver askForPassword -int 1
-      /usr/bin/defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 5
-    '';
+  system.activationScripts.alwaysOn = lib.optionalString (alwaysOn && pkgs.stdenv.isDarwin) ''
+    echo "==> Configuring always-on power management (pmset)..."
+    /usr/sbin/pmset -a sleep 0 displaysleep 10 disksleep 0
+    echo "==> Enabling screensaver password lock..."
+    /usr/bin/defaults -currentHost write com.apple.screensaver askForPassword -int 1
+    /usr/bin/defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 5
+  '';
 }

--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -433,14 +433,17 @@
   # • Hard disk sleep  → never
   # • Screensaver      → enabled with password lock after 5 s grace
   #   (uses the default macOS screensaver — Aerial on supported machines)
-  power.sleep = lib.optionalAttrs (alwaysOn && pkgs.stdenv.isDarwin) {
-    computer = "never";
-    display = 10;
-    harddisk = "never";
-  };
-
-  system.defaults.screensaver = lib.optionalAttrs (alwaysOn && pkgs.stdenv.isDarwin) {
-    askForPassword = true;
-    askForPasswordDelay = 5;
-  };
+  #
+  # Uses pmset directly instead of nix-darwin's power.sleep module because
+  # that module uses `systemsetup`, which doesn't persist settings across
+  # reboots on Apple Silicon. Similarly, system.defaults.screensaver has
+  # known reliability issues (nix-darwin #908, #1207).
+  system.activationScripts.alwaysOn =
+    lib.optionalString (alwaysOn && pkgs.stdenv.isDarwin) ''
+      echo "==> Configuring always-on power management (pmset)..."
+      /usr/sbin/pmset -a sleep 0 displaysleep 10 disksleep 0
+      echo "==> Enabling screensaver password lock..."
+      /usr/bin/defaults -currentHost write com.apple.screensaver askForPassword -int 1
+      /usr/bin/defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 5
+    '';
 }


### PR DESCRIPTION
## Problem
`alwaysOn = true` was not working on the Mac Mini (Apple Silicon).

## Root Cause
nix-darwin's `power.sleep` module uses `systemsetup`, which **doesn't persist settings across reboots on Apple Silicon**. Similarly, `system.defaults.screensaver` has known reliability issues ([#908](https://github.com/nix-darwin/nix-darwin/issues/908), [#1207](https://github.com/nix-darwin/nix-darwin/issues/1207)).

## Fix
Replace both nix-darwin modules with a direct activation script that uses the correct, persistent macOS APIs:

```bash
pmset -a sleep 0 displaysleep 10 disksleep 0
defaults -currentHost write com.apple.screensaver askForPassword -int 1
defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 5
```

- `pmset -a` sets for all power sources (AC + battery) and persists to `/Library/Preferences/SystemConfiguration/com.apple.PowerManagement.plist`
- `defaults -currentHost` writes to the host-specific domain, which is where screensaver password settings live
- Runs during `rebuild` as part of nix-darwin activation (which runs as root via `sudo`)

### Before (didn't persist on Apple Silicon)
```nix
power.sleep = { computer = "never"; display = 10; harddisk = "never"; };
system.defaults.screensaver = { askForPassword = true; askForPasswordDelay = 5; };
```

### After (direct, persistent)
```nix
system.activationScripts.alwaysOn = lib.optionalString (alwaysOn && pkgs.stdenv.isDarwin) '\
  /usr/sbin/pmset -a sleep 0 displaysleep 10 disksleep 0
  /usr/bin/defaults -currentHost write com.apple.screensaver askForPassword -int 1
  /usr/bin/defaults -currentHost write com.apple.screensaver askForPasswordDelay -int 5
';
```