### PR TITLE
feat: add verbose activation progress for nix-darwin rebuild

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -223,6 +223,13 @@ in
     # '';
   };
 
+  # Print progress marker before home-manager writes all managed files.
+  # The writeBoundary is the long silent phase where hundreds of symlinks
+  # are created. This marker tells the user something is happening.
+  home.activation.preWriteBoundary = lib.hm.dag.entryBefore [ "writeBoundary" ] ''
+    echo "==> Writing home-manager configuration..."
+  '';
+
   # Keep pnpm global packages in sync from the managed manifest when available.
   # This is best-effort to avoid making activation fail when pnpm is unavailable.
   home.activation.syncPnpmGlobalPackages = lib.hm.dag.entryAfter [ "writeBoundary" ] ''

--- a/Hooks/nix/post.sh
+++ b/Hooks/nix/post.sh
@@ -336,10 +336,10 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 
 	# Build nh darwin command (with nix run fallback for first-time setup)
 	if command -v nh &>/dev/null; then
-		DARWIN_CMD="nh darwin switch '${NIX_FLAKE_DIR}' -H default --impure"
+		DARWIN_CMD="nh darwin switch '${NIX_FLAKE_DIR}' -H default --impure --verbose"
 	else
 		echo "nh not found, using nix run nixpkgs#nh for first-time setup..."
-		DARWIN_CMD="nix run nixpkgs#nh -- darwin switch '${NIX_FLAKE_DIR}' -H default --impure"
+		DARWIN_CMD="nix run nixpkgs#nh -- darwin switch '${NIX_FLAKE_DIR}' -H default --impure --verbose"
 	fi
 
 	REBUILD_CMD="ulimit -n 10240 && NIX_USER_CONFIG_DIR='${NIX_LINK_DIR}' ${DARWIN_CMD}"


### PR DESCRIPTION
Two changes to make the `> Activating configuration` phase visible:

1. **`home.activation.preWriteBoundary`** — Adds a `==>` progress marker that prints *before* home-manager writes hundreds of symlinks. This brackets the long silent phase with visible start/end markers:
   - `==> Writing home-manager configuration...` (before symlinks)
   - `==> Syncing pnpm global packages...` (after symlinks)
   - `==> Initializing podman VM...` (after, on lite macOS)

2. **`--verbose` flag on `nh darwin switch`** — Makes nh print each activation step name, so you can see which phase is running instead of just `> Activating configuration`.

Together with the previous PR's `==>` markers in the rebuild hook, the full activation output will now look like:

```
==> Starting nix-darwin rebuild (may prompt for sudo)...
> Activating configuration
==> Writing home-manager configuration...
  [symlink operations — previously silent]
==> Syncing pnpm global packages (home-manager activation)...
==> Initializing podman VM (lite macOS desktop)...
==> Setting up /Applications...
==> nix-darwin rebuild SUCCEEDED after 47s! (darwin + home-manager)
==> Post-rebuild: syncing pnpm global packages...
==> Stopped sudo keepalive
```