### PR TITLE
feat(secretspec): replace .env.dotfiles with SecretSpec + 1Password

### DIFF
--- a/Configs/secretspec.group.toml
+++ b/Configs/secretspec.group.toml
@@ -1,0 +1,2 @@
+description = "Declarative secrets via SecretSpec + 1Password. Replaces ~/.env.dotfiles."
+presets = ["dev"]

--- a/Configs/secretspec/secretspec.toml
+++ b/Configs/secretspec/secretspec.toml
@@ -5,7 +5,12 @@ revision = "1.0"
 # ── Providers ──
 [providers]
 keyring = "keyring://"
-dotfiles = "onepassword+token://Development"
+dotfiles = "onepassword+token://dev"
+
+# The shared item name within the vault. All secrets live as fields
+# in the "dotfiles" entry, organised by section.
+# Set via `secretspec config provider edit dotfiles --folder-prefix dotfiles`
+# or in ~/.config/secretspec/config.toml under [providers.onepassword].
 
 # 1Password service account token resolved from Keychain
 [providers.dotfiles.requires]
@@ -17,7 +22,7 @@ providers = ["dotfiles"]
 required = true
 
 # ── Secrets ──
-# Each secret lives in the shared "dotfiles-secrets" 1Password item.
+# Each secret lives in the shared "dotfiles" 1Password item.
 # path = section name, key defaults to the secret name (e.g. GITHUB_TOKEN
 # resolves to a field literally named "GITHUB_TOKEN" in that section).
 

--- a/Configs/secretspec/secretspec.toml
+++ b/Configs/secretspec/secretspec.toml
@@ -5,26 +5,21 @@ revision = "1.0"
 # ── Providers ──
 [providers]
 keyring = "keyring://"
-dotfiles = "onepassword+token://dev"
+dotfiles = "onepassword+token://Dotfiles"
 
-# The shared item name within the vault. All secrets live as fields
-# in the "dotfiles" entry, organised by section.
-# Set via `secretspec config provider edit dotfiles --folder-prefix dotfiles`
-# or in ~/.config/secretspec/config.toml under [providers.onepassword].
-
-# 1Password service account token resolved from Keychain
+# The dotfiles provider needs OP_SERVICE_ACCOUNT_TOKEN to authenticate.
+# This is the only fork feature we use.
 [providers.dotfiles.requires]
 service_token = { secret = "OP_SERVICE_ACCOUNT_TOKEN" }
 
-# ── Defaults ──
+# ── Secrets ──
+# Standard one-item-per-secret model. Each secret is a separate
+# 1Password item in the "Dotfiles" vault, named after the env var.
+# (Requires folder_prefix = "{key}" in ~/.config/secretspec/config.toml)
+
 [profiles.default.defaults]
 providers = ["dotfiles"]
 required = true
-
-# ── Secrets ──
-# Each secret lives in the shared "dotfiles" 1Password item.
-# path = section name, key defaults to the secret name (e.g. GITHUB_TOKEN
-# resolves to a field literally named "GITHUB_TOKEN" in that section).
 
 [profiles.default]
 OP_SERVICE_ACCOUNT_TOKEN = {
@@ -32,62 +27,47 @@ OP_SERVICE_ACCOUNT_TOKEN = {
   providers = ["keyring"]
 }
 GITHUB_TOKEN = {
-  description = "GitHub personal access token for gh CLI and API access",
-  providers = [{ provider = "dotfiles", path = ["GitHub"] }]
+  description = "GitHub personal access token for gh CLI and API access"
 }
 ANTHROPIC_API_KEY = {
-  description = "Anthropic API key for Claude (pi, opencode, etc.)",
-  providers = [{ provider = "dotfiles", path = ["AI"] }]
+  description = "Anthropic API key for Claude (pi, opencode, etc.)"
 }
 OPENAI_API_KEY = {
-  description = "OpenAI API key for GPT models and Codex",
-  providers = [{ provider = "dotfiles", path = ["AI"] }]
+  description = "OpenAI API key for GPT models and Codex"
 }
 GOOGLE_API_KEY = {
-  description = "Google Gemini API key",
-  providers = [{ provider = "dotfiles", path = ["AI"] }]
+  description = "Google Gemini API key"
 }
 GROQ_API_KEY = {
-  description = "Groq API key for fast inference",
-  providers = [{ provider = "dotfiles", path = ["AI"] }]
+  description = "Groq API key for fast inference"
 }
 OLLAMA_TOKEN = {
-  description = "Ollama API token",
-  providers = [{ provider = "dotfiles", path = ["AI"] }]
+  description = "Ollama API token"
 }
 REPLICATE_API_TOKEN = {
-  description = "Replicate API token for model inference",
-  providers = [{ provider = "dotfiles", path = ["AI"] }]
+  description = "Replicate API token for model inference"
 }
 HUGGING_FACE_TOKEN = {
-  description = "HuggingFace API token for model access",
-  providers = [{ provider = "dotfiles", path = ["AI"] }]
+  description = "HuggingFace API token for model access"
 }
 PULUMI_TOKEN = {
-  description = "Pulumi access token for infrastructure management",
-  providers = [{ provider = "dotfiles", path = ["Infra"] }]
+  description = "Pulumi access token for infrastructure management"
 }
 CLOUDFLARE_API_TOKEN = {
-  description = "Cloudflare API token for Workers, Pages, DNS",
-  providers = [{ provider = "dotfiles", path = ["Infra"] }]
+  description = "Cloudflare API token for Workers, Pages, DNS"
 }
 NPM_TOKEN = {
-  description = "npm registry publish token",
-  providers = [{ provider = "dotfiles", path = ["Registries"] }]
+  description = "npm registry publish token"
 }
 FLAKEHUB_TOKEN = {
-  description = "FlakeHub token for Nix flake publishing",
-  providers = [{ provider = "dotfiles", path = ["Registries"] }]
+  description = "FlakeHub token for Nix flake publishing"
 }
 DISCORD_TOKEN = {
-  description = "Discord bot token",
-  providers = [{ provider = "dotfiles", path = ["Other"] }]
+  description = "Discord bot token"
 }
 DISCORD_CLIENT_ID = {
-  description = "Discord application client ID",
-  providers = [{ provider = "dotfiles", path = ["Other"] }]
+  description = "Discord application client ID"
 }
 DISCORD_CLIENT_SECRET = {
-  description = "Discord application client secret",
-  providers = [{ provider = "dotfiles", path = ["Other"] }]
+  description = "Discord application client secret"
 }

--- a/Configs/secretspec/secretspec.toml
+++ b/Configs/secretspec/secretspec.toml
@@ -5,7 +5,9 @@ revision = "1.0"
 # ── Providers ──
 [providers]
 keyring = "keyring://"
-dotfiles = "onepassword+token://Dotfiles"
+
+[providers.dotfiles]
+uri = "onepassword+token://Dotfiles"
 
 # The dotfiles provider needs OP_SERVICE_ACCOUNT_TOKEN to authenticate.
 # This is the only fork feature we use.
@@ -22,52 +24,21 @@ providers = ["dotfiles"]
 required = true
 
 [profiles.default]
-OP_SERVICE_ACCOUNT_TOKEN = {
-  description = "1Password service account token for automated access",
-  providers = ["keyring"]
-}
-GITHUB_TOKEN = {
-  description = "GitHub personal access token for gh CLI and API access"
-}
-ANTHROPIC_API_KEY = {
-  description = "Anthropic API key for Claude (pi, opencode, etc.)"
-}
-OPENAI_API_KEY = {
-  description = "OpenAI API key for GPT models and Codex"
-}
-GOOGLE_API_KEY = {
-  description = "Google Gemini API key"
-}
-GROQ_API_KEY = {
-  description = "Groq API key for fast inference"
-}
-OLLAMA_TOKEN = {
-  description = "Ollama API token"
-}
-REPLICATE_API_TOKEN = {
-  description = "Replicate API token for model inference"
-}
-HUGGING_FACE_TOKEN = {
-  description = "HuggingFace API token for model access"
-}
-PULUMI_TOKEN = {
-  description = "Pulumi access token for infrastructure management"
-}
-CLOUDFLARE_API_TOKEN = {
-  description = "Cloudflare API token for Workers, Pages, DNS"
-}
-NPM_TOKEN = {
-  description = "npm registry publish token"
-}
-FLAKEHUB_TOKEN = {
-  description = "FlakeHub token for Nix flake publishing"
-}
-DISCORD_TOKEN = {
-  description = "Discord bot token"
-}
-DISCORD_CLIENT_ID = {
-  description = "Discord application client ID"
-}
-DISCORD_CLIENT_SECRET = {
-  description = "Discord application client secret"
-}
+OP_SERVICE_ACCOUNT_TOKEN.description = "1Password service account token for automated access"
+OP_SERVICE_ACCOUNT_TOKEN.providers = ["keyring"]
+
+GITHUB_TOKEN.description = "GitHub personal access token for gh CLI and API access"
+ANTHROPIC_API_KEY.description = "Anthropic API key for Claude (pi, opencode, etc.)"
+OPENAI_API_KEY.description = "OpenAI API key for GPT models and Codex"
+GOOGLE_API_KEY.description = "Google Gemini API key"
+GROQ_API_KEY.description = "Groq API key for fast inference"
+OLLAMA_TOKEN.description = "Ollama API token"
+REPLICATE_API_TOKEN.description = "Replicate API token for model inference"
+HUGGING_FACE_TOKEN.description = "HuggingFace API token for model access"
+PULUMI_TOKEN.description = "Pulumi access token for infrastructure management"
+CLOUDFLARE_API_TOKEN.description = "Cloudflare API token for Workers, Pages, DNS"
+NPM_TOKEN.description = "npm registry publish token"
+FLAKEHUB_TOKEN.description = "FlakeHub token for Nix flake publishing"
+DISCORD_TOKEN.description = "Discord bot token"
+DISCORD_CLIENT_ID.description = "Discord application client ID"
+DISCORD_CLIENT_SECRET.description = "Discord application client secret"

--- a/Configs/secretspec/secretspec.toml
+++ b/Configs/secretspec/secretspec.toml
@@ -1,0 +1,88 @@
+[project]
+name = "dotfiles"
+revision = "1.0"
+
+# ── Providers ──
+[providers]
+keyring = "keyring://"
+dotfiles = "onepassword+token://Development"
+
+# 1Password service account token resolved from Keychain
+[providers.dotfiles.requires]
+service_token = { secret = "OP_SERVICE_ACCOUNT_TOKEN" }
+
+# ── Defaults ──
+[profiles.default.defaults]
+providers = ["dotfiles"]
+required = true
+
+# ── Secrets ──
+# Each secret lives in the shared "dotfiles-secrets" 1Password item.
+# path = section name, key defaults to the secret name (e.g. GITHUB_TOKEN
+# resolves to a field literally named "GITHUB_TOKEN" in that section).
+
+[profiles.default]
+OP_SERVICE_ACCOUNT_TOKEN = {
+  description = "1Password service account token for automated access",
+  providers = ["keyring"]
+}
+GITHUB_TOKEN = {
+  description = "GitHub personal access token for gh CLI and API access",
+  providers = [{ provider = "dotfiles", path = ["GitHub"] }]
+}
+ANTHROPIC_API_KEY = {
+  description = "Anthropic API key for Claude (pi, opencode, etc.)",
+  providers = [{ provider = "dotfiles", path = ["AI"] }]
+}
+OPENAI_API_KEY = {
+  description = "OpenAI API key for GPT models and Codex",
+  providers = [{ provider = "dotfiles", path = ["AI"] }]
+}
+GOOGLE_API_KEY = {
+  description = "Google Gemini API key",
+  providers = [{ provider = "dotfiles", path = ["AI"] }]
+}
+GROQ_API_KEY = {
+  description = "Groq API key for fast inference",
+  providers = [{ provider = "dotfiles", path = ["AI"] }]
+}
+OLLAMA_TOKEN = {
+  description = "Ollama API token",
+  providers = [{ provider = "dotfiles", path = ["AI"] }]
+}
+REPLICATE_API_TOKEN = {
+  description = "Replicate API token for model inference",
+  providers = [{ provider = "dotfiles", path = ["AI"] }]
+}
+HUGGING_FACE_TOKEN = {
+  description = "HuggingFace API token for model access",
+  providers = [{ provider = "dotfiles", path = ["AI"] }]
+}
+PULUMI_TOKEN = {
+  description = "Pulumi access token for infrastructure management",
+  providers = [{ provider = "dotfiles", path = ["Infra"] }]
+}
+CLOUDFLARE_API_TOKEN = {
+  description = "Cloudflare API token for Workers, Pages, DNS",
+  providers = [{ provider = "dotfiles", path = ["Infra"] }]
+}
+NPM_TOKEN = {
+  description = "npm registry publish token",
+  providers = [{ provider = "dotfiles", path = ["Registries"] }]
+}
+FLAKEHUB_TOKEN = {
+  description = "FlakeHub token for Nix flake publishing",
+  providers = [{ provider = "dotfiles", path = ["Registries"] }]
+}
+DISCORD_TOKEN = {
+  description = "Discord bot token",
+  providers = [{ provider = "dotfiles", path = ["Other"] }]
+}
+DISCORD_CLIENT_ID = {
+  description = "Discord application client ID",
+  providers = [{ provider = "dotfiles", path = ["Other"] }]
+}
+DISCORD_CLIENT_SECRET = {
+  description = "Discord application client secret",
+  providers = [{ provider = "dotfiles", path = ["Other"] }]
+}

--- a/Configs/shell/.config/shell/env.sh
+++ b/Configs/shell/.config/shell/env.sh
@@ -120,11 +120,9 @@ if [ -f "$HOME/.config/agents/agents.env.sh" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Secrets (optional, not committed)
+# Secrets — 1Password-backed via SecretSpec, no plaintext on disk
 # ---------------------------------------------------------------------------
-if [ -f "$HOME/.env.dotfiles" ]; then
-	set -a
+if [ -f "$HOME/.config/shell/secrets.sh" ]; then
 	# shellcheck disable=SC1091
-	. "$HOME/.env.dotfiles"
-	set +a
+	. "$HOME/.config/shell/secrets.sh"
 fi

--- a/Configs/shell/.config/shell/secrets.sh
+++ b/Configs/shell/.config/shell/secrets.sh
@@ -1,0 +1,21 @@
+# ---------------------------------------------------------------------------
+# SecretSpec + 1Password secret injection
+# ---------------------------------------------------------------------------
+# Replaces ~/.env.dotfiles. Secrets are declared in ~/secretspec.toml and
+# resolved at runtime from a 1Password vault. Never written to disk.
+#
+# Usage:
+#   ssr <command>   Run a command with secrets injected ephemerally
+#   ssload          Load all secrets into the current shell session
+#
+# The LLM reads ~/secretspec.toml to discover what secrets are available
+# (names + descriptions) without seeing values.
+# ---------------------------------------------------------------------------
+
+ssr() {
+	secretspec run -f "$HOME/secretspec.toml" -- "$@"
+}
+
+ssload() {
+	eval "$(secretspec run -f "$HOME/secretspec.toml" -- env | sed 's/^/export /')"
+}


### PR DESCRIPTION
## Summary

Replaces `~/.env.dotfiles` (plaintext secrets on disk) with declarative SecretSpec + 1Password integration.

## Changes

- **New `secretspec` config group**: `secretspec.toml` at `~/` level declares all 17 secrets with descriptions, so the LLM discovers what's available without seeing values
- **New `secrets.sh`**: `ssr` wrapper uses `secretspec run -f ~/secretspec.toml` for ephemeral secret injection
- **Updated `env.sh`**: sources `secrets.sh` instead of `~/.env.dotfiles`
- Uses **forked secretspec** (`ifiokjr/secretspec` branch `feat/provider-secret-locations`) for the `[providers.<name>.requires]` feature — lets the 1Password provider declare its dependency on `OP_SERVICE_ACCOUNT_TOKEN` (resolved from macOS Keychain)

## Architecture

```
secretspec.toml (LLM reads → discovers names + descriptions)
    ↓
secretspec run -f ~/secretspec.toml -- <command>
    ↓
OP_SERVICE_ACCOUNT_TOKEN ← keyring (macOS Keychain)
    ↓
onepassword+token://Dotfiles → op item get <key> --vault Dotfiles
    ↓
secrets injected into subprocess env → destroyed on exit
```

## Prerequisites

- Forked secretspec from `ifiokjr/secretspec` (branch `feat/provider-secret-locations`)
- `OP_SERVICE_ACCOUNT_TOKEN` stored via `secretspec set --provider keyring`
- Dotfiles vault populated with one item per secret (e.g. `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, ...)