### PR TITLE
revert: switch back to .env.dotfiles while 1Password setup is incomplete

### DIFF
--- a/Configs/nushell/.config/nushell/modules/secrets.nu
+++ b/Configs/nushell/.config/nushell/modules/secrets.nu
@@ -1,15 +1,27 @@
-# secrets.nu — SecretSpec + 1Password secret injection
+# secrets.nu - Load environment variables from ~/.env.dotfiles
 #
-# Replaces the old .env.dotfiles loader. Secrets are resolved at runtime
-# from a 1Password vault via secretspec and never written to disk.
-#
-# Usage:
-#   ssr <command>   Run a command with secrets injected ephemerally
-#   ssload          Load all secrets into the current shell session
-# Run a command with secrets injected ephemerally
-export def ssr [...args] { ^secretspec run -f $"($env.HOME)/secretspec.toml" -- ...$args }
-# Load all secrets into the current shell (use sparingly)
-export def --env ssload [] {
-    let output = (^secretspec run -f $"($env.HOME)/secretspec.toml" -- env)
-    $output | lines | parse "{key}={value}" | transpose -r -d | load-env
+# Parses KEY=VALUE lines from the secrets file and loads them into the
+# environment. Handles quoted values, comments, and blank lines.
+export def --env load [] {
+	let secrets_file = $"($env.HOME)/.env.dotfiles"
+	if not ($secrets_file | path exists) { return }
+	let env_vars = (
+		open $secrets_file | lines | where { |line|
+			let trimmed = ($line | str trim)
+			($trimmed | is-not-empty) and (not ($trimmed | str starts-with "#"))
+		} | each { |line|
+			let eq_pos = ($line | str index-of "=")
+			if ($eq_pos == -1) { return null }
+			let key = ($line | str substring 0..<$eq_pos | str trim)
+			let value = ($line
+				| str substring ($eq_pos + 1)..
+				| str trim
+				| str replace -r '^"(.*)"$' '$1'
+				| str replace -r "^'(.*)'$" '$1')
+			{ $key: $value }
+		} | where { $in != null } | reduce --fold {} { |it, acc| $acc | merge $it }
+	)
+	if ($env_vars | is-not-empty) {
+		$env_vars | load-env
+	}
 }

--- a/Configs/shell/.config/shell/env.sh
+++ b/Configs/shell/.config/shell/env.sh
@@ -120,9 +120,11 @@ if [ -f "$HOME/.config/agents/agents.env.sh" ]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Secrets — 1Password-backed via SecretSpec, no plaintext on disk
+# Secrets (optional, not committed)
 # ---------------------------------------------------------------------------
-if [ -f "$HOME/.config/shell/secrets.sh" ]; then
+if [ -f "$HOME/.env.dotfiles" ]; then
+	set -a
 	# shellcheck disable=SC1091
-	. "$HOME/.config/shell/secrets.sh"
+	. "$HOME/.env.dotfiles"
+	set +a
 fi


### PR DESCRIPTION
Emergency revert. The secretspec/1Password integration isn't ready yet — token not in keyring, vault items not created. Restores old .env.dotfiles-based loading in env.sh and nushell/secrets.nu.