### PR TITLE
feat(nix): add gnome-keyring on Linux

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -196,7 +196,10 @@ in
     )
     ++ lib.optionals pkgs.stdenv.isLinux (
       # Linux-only packages (macOS equivalents are in darwin.nix systemPackages)
-      lib.optionals (!lite) [
+      [
+        gnome-keyring
+      ]
+      ++ lib.optionals (!lite) [
         blender # broken on macOS in nixpkgs; macOS uses Homebrew casks
         ghostty
         google-chrome


### PR DESCRIPTION
## Summary
- Add gnome-keyring to Home Manager packages on Linux only
- Keep it available in lite mode for keyring-backed secret storage

## Verification
- nix flake check ./Configs/nix/.config/nix --impure --no-build