### PR TITLE
feat(secretspec): add agent skill and ssload helpers

### DIFF
--- a/.agents/skills/dotfiles-secretspec/SKILL.md
+++ b/.agents/skills/dotfiles-secretspec/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: dotfiles-secretspec
+description: Dotfiles-specific SecretSpec + 1Password workflow for accessing tokens and API keys without ambient env injection. Use when working in ifiokjr/dotfiles, when commands need secrets like GITHUB_TOKEN or ANTHROPIC_API_KEY, or when editing SecretSpec, shell, Nushell, or agent setup.
+---
+
+# Dotfiles SecretSpec
+
+This repository uses Ifiok's forked SecretSpec setup for secrets. Reference implementation: <https://github.com/ifiokjr/secretspec>.
+
+## Core rule
+
+Secrets are **not injected by default**. Do not assume `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc. exist in the ambient shell environment.
+
+The dotfiles setup provides two modes:
+
+- `ssr <command>`: preferred. Runs one command with SecretSpec secrets injected only for that subprocess.
+- `ssload`: convenience. Loads all declared SecretSpec secrets into the current shell session; use only when repeated commands need secrets.
+
+`ss` is the SecretSpec CLI wrapper using `~/secretspec.toml`.
+
+## Commands
+
+Check configured secrets:
+
+```sh
+ss check
+```
+
+Run a command with secrets lazily injected:
+
+```sh
+ssr gh pr list
+ssr env | grep GITHUB_TOKEN
+```
+
+Load all secrets into the current shell session:
+
+```sh
+ssload
+```
+
+After `ssload`, normal commands can use secrets without `ssr` until the shell exits or variables are unset.
+
+## Security guidance
+
+Prefer `ssr <command>` because secrets stay scoped to a child process. Use `ssload` only for interactive sessions where convenience is worth keeping secrets in the current environment.
+
+Never print full secret values in logs or chat. Use masked output if verification is needed.
+
+## Implementation notes
+
+- `~/secretspec.toml` is deployed from `Configs/secretspec/secretspec.toml`.
+- `OP_SERVICE_ACCOUNT_TOKEN` is resolved through SecretSpec providers, normally keyring/keychain with optional dotenv or 1Password fallback.
+- The fork supports provider dependencies so token-backed 1Password providers can depend on `OP_SERVICE_ACCOUNT_TOKEN`.
+- POSIX shell helpers live in `Configs/shell/.config/shell/secrets.sh`.
+- Nushell helpers live in `Configs/nushell/.config/nushell/modules/secrets.nu`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ This repository is a cross-platform, Tuckr-managed dotfiles repository that depl
   - `rebuild` (when Nix config or packages change)
   - `docker build -t dotfiles-test .` (when Nix config or packages change for Linux confidence)
 - Formatting/style rule: if any line(s) are commented out, include an explanation comment explaining why they are disabled.
+- Secret handling: this repo uses the dotfiles-specific SecretSpec + 1Password workflow. Secrets are not ambient; use `ssr <command>` for lazy injection or `ssload` only when a shell session intentionally needs all secrets. See `.agents/skills/dotfiles-secretspec/SKILL.md`.
 - Git workflow requirements:
   - Use feature branches like `feat/*`, `fix/*`, `ci/*`, `chore/*` (no `codex/` prefix).
   - Use Conventional Commits.

--- a/Configs/nushell/.config/nushell/config.nu
+++ b/Configs/nushell/.config/nushell/config.nu
@@ -102,7 +102,7 @@ def --env pnpm_auto_activate [] {
 $env.config.hooks.env_change.PWD = (($env.config.hooks.env_change | get -o PWD | default []) | append { |before, after| pnpm_auto_activate })
 pnpm_auto_activate
 # Secrets
-use modules/secrets.nu ssr
+use modules/secrets.nu [ssr, ssload]
 alias ss = secretspec -f $"($env.HOME)/secretspec.toml"
 # General aliases
 # Reload shell

--- a/Configs/nushell/.config/nushell/modules/secrets.nu
+++ b/Configs/nushell/.config/nushell/modules/secrets.nu
@@ -5,5 +5,39 @@
 #
 # Usage:
 #   ssr <command>   Run a command with secrets injected ephemerally
-# Run a command with all secrets injected ephemerally
+#   ssload          Load all declared secrets into the current shell session
+# Run a command with all secrets injected ephemerally.
 export def ssr [...args] { ^secretspec run -f $"($env.HOME)/secretspec.toml" -- ...$args }
+# Load all declared secrets into the current Nushell session.
+# Prefer `ssr <command>` unless you intentionally want secrets resident in the shell.
+export def --env ssload [] {
+    let secretspec_file = $"($env.HOME)/secretspec.toml"
+    if not ($secretspec_file | path exists) {
+        error make {
+            msg: $"ssload: missing ($secretspec_file)"
+        }
+    }
+    let keys = (
+        open $secretspec_file | from toml | get profiles.default | columns | where { |key| $key != "defaults" }
+    )
+    if ($keys | is-empty) {
+        error make {
+            msg: $"ssload: no secrets found in ($secretspec_file)"
+        }
+    }
+    let env_vars = (
+        ^secretspec run -f $secretspec_file -- env | lines | each { |line|
+            let idx = ($line | str index-of "=")
+            if $idx == -1 { return null }
+
+            let key = ($line | str substring 0..<$idx)
+            if $key not-in $keys { return null }
+
+            let value = ($line | str substring ($idx + 1)..)
+            { $key: $value }
+        } | where { |item| $item != null } | reduce --fold {} { |item, acc| $acc | merge $item }
+    )
+    if ($env_vars | is-not-empty) {
+        $env_vars | load-env
+    }
+}

--- a/Configs/shell/.config/shell/secrets.sh
+++ b/Configs/shell/.config/shell/secrets.sh
@@ -6,7 +6,9 @@
 # 1Password vault. Never written to disk in plaintext.
 #
 # Usage:
+#   ss <args>        Run the SecretSpec CLI with ~/secretspec.toml
 #   ssr <command>    Run a command with secrets injected ephemerally
+#   ssload           Load all declared secrets into the current shell session
 # ---------------------------------------------------------------------------
 
 ssr() {
@@ -15,4 +17,38 @@ ssr() {
 
 ss() {
 	secretspec -f "$HOME/secretspec.toml" "$@"
+}
+
+ssload() {
+	_ss_file="$HOME/secretspec.toml"
+	if [ ! -f "$_ss_file" ]; then
+		echo "ssload: missing $_ss_file" >&2
+		return 1
+	fi
+	if ! command -v python3 >/dev/null 2>&1; then
+		echo "ssload: python3 is required to quote secret values safely" >&2
+		return 1
+	fi
+
+	_ss_keys=$(sed -n 's/^\[profiles\.default\.\([A-Za-z_][A-Za-z0-9_]*\)\]$/\1/p' "$_ss_file")
+	if [ -z "$_ss_keys" ]; then
+		echo "ssload: no secrets found in $_ss_file" >&2
+		unset _ss_file _ss_keys
+		return 1
+	fi
+
+	# `secretspec run` resolves every declared secret once. Python runs inside
+	# that environment and emits shell-quoted exports for declared secret keys only.
+	eval "$(
+		SECRETSPEC_DOTFILES_KEYS="$_ss_keys" secretspec run -f "$_ss_file" -- python3 - <<'PY'
+import os
+import shlex
+
+for key in os.environ.get("SECRETSPEC_DOTFILES_KEYS", "").splitlines():
+    value = os.environ.get(key)
+    if value is not None:
+        print(f"export {key}={shlex.quote(value)}")
+PY
+	)"
+	unset _ss_file _ss_keys
 }

--- a/docs/agents/skills.md
+++ b/docs/agents/skills.md
@@ -4,6 +4,7 @@ Use skills when the user explicitly names one or when the task clearly matches a
 
 ## Available Skills
 
+- `dotfiles-secretspec`: dotfiles-specific SecretSpec + 1Password workflow. Path: `.agents/skills/dotfiles-secretspec/SKILL.md`
 - `backblaze-upload`: upload files to Backblaze B2 and generate links. Path: `/Users/ifiokjr/.codex/skills/backblaze-upload/SKILL.md`
 - `figma`: use Figma MCP for node context/screenshots/variables/design-to-code. Path: `/Users/ifiokjr/.codex/skills/figma/SKILL.md`
 - `gh-address-comments`: address PR comments via `gh`. Path: `/Users/ifiokjr/.codex/skills/gh-address-comments/SKILL.md`

--- a/readme.md
+++ b/readme.md
@@ -317,6 +317,7 @@ Dotfiles secrets are declared in `~/secretspec.toml` and resolved lazily from Se
 ```bash
 ss check          # verify declared secrets
 ssr <command>     # run a command with secrets injected ephemerally
+ssload            # load all declared secrets into the current shell session
 ```
 
 `~/.env.dotfiles` is no longer the primary secret store. It is only an optional fallback for `OP_SERVICE_ACCOUNT_TOKEN` when keyring/keychain is unavailable or being reset.


### PR DESCRIPTION
## Summary
- add project-level dotfiles SecretSpec skill under .agents/skills
- document lazy secret access via ssr and full-session loading via ssload
- add ssload helpers for POSIX shell and Nushell
- update AGENTS.md and docs so agent harnesses know secrets are not ambient

## Verification
- dprint check --config Configs/dprint/dprint.json
- shellcheck setup setup-tuckr-symlink.sh Hooks/*/post.sh Configs/shell/.config/shell/secrets.sh
- nu --no-config-file Configs/scripts/.local/bin/test_scripts