### PR TITLE
fix(nix): include node in lite installs

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -59,6 +59,7 @@ in
       neovim
       nixd
       nixfmt
+      nodejs
       extra.ollama
       opencode
       python3


### PR DESCRIPTION
## Summary
- install `nodejs` in the base Home Manager package set so `--lite` macOS installs still have `node`
- keeps pnpm global tooling usable on Mac minis without requiring the heavier non-lite package set

## Verification
- `dprint check --config Configs/dprint/dprint.json`
- `nix eval --raw --impure --expr 'let flake = builtins.getFlake (toString ./Configs/nix/.config/nix); in flake.inputs.nixpkgs.legacyPackages.${builtins.currentSystem}.nodejs.version'`
- `nix flake check ./Configs/nix/.config/nix --impure --no-build`
