### PR TITLE
fix(nix): auto-start podman VM on lite macOS desktops

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -179,13 +179,19 @@
   # Auto-start the podman VM on login for lite desktop Macs.
   # Without this, `docker` (podman wrapper) fails with "daemon not running".
   # `podman machine start` is idempotent — exits cleanly if already running.
+  # After starting, caches the DOCKER_HOST socket path for shell startup.
   launchd.agents.podman-machine = lib.mkIf (isDesktop && lite) {
     path = [ pkgs.podman ];
     serviceConfig = {
       ProgramArguments = [
-        "${pkgs.podman}/bin/podman"
-        "machine"
-        "start"
+        "/bin/sh"
+        "-c"
+        (
+          "${pkgs.podman}/bin/podman machine start 2>/dev/null || true; "
+          + "mkdir -p $HOME/.local/share/podman; "
+          + "_sock=$(${pkgs.podman}/bin/podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanPipePath}}' 2>/dev/null | tr -d '\\n'); "
+          + "[ -n \"$_sock\" ] && echo \"unix://$_sock\" > $HOME/.local/share/podman/docker-host || true"
+        )
       ];
       RunAtLoad = true;
       KeepAlive = false;

--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -176,6 +176,24 @@
   # Use Tailscale as exit node / subnet router (optional)
   # services.tailscale.useRoutingFeatures = "both";
 
+  # Auto-start the podman VM on login for lite desktop Macs.
+  # Without this, `docker` (podman wrapper) fails with "daemon not running".
+  # `podman machine start` is idempotent — exits cleanly if already running.
+  launchd.agents.podman-machine = lib.mkIf (isDesktop && lite) {
+    path = [ pkgs.podman ];
+    serviceConfig = {
+      ProgramArguments = [
+        "${pkgs.podman}/bin/podman"
+        "machine"
+        "start"
+      ];
+      RunAtLoad = true;
+      KeepAlive = false;
+      StandardOutPath = "/tmp/podman-machine-start.log";
+      StandardErrorPath = "/tmp/podman-machine-start.log";
+    };
+  };
+
   # Use global sudo timestamp so credentials are shared across all processes.
   # Required because nix-darwin's Homebrew module runs `brew bundle` in a
   # different process tree during activation, and brew's internal `sudo`

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -280,12 +280,21 @@ in
 
   # Initialize and start podman VM for Docker compatibility on lite macOS desktops.
   # Idempotent: podman machine init/start are no-ops if machine already exists/running.
+  # --rootful enables root-level container capabilities (ports <1024, etc.).
   home.activation.initPodmanMachine = lib.hm.dag.entryAfter [ "writeBoundary" ] (
     lib.optionalString (isDesktop && lite && pkgs.stdenv.isDarwin) ''
-      echo "==> Initializing podman VM (lite macOS desktop)…"
+      echo "==> Initializing rootful podman VM (lite macOS desktop)…"
       if command -v podman >/dev/null 2>&1; then
-        ${pkgs.podman}/bin/podman machine init 2>/dev/null || true
+        ${pkgs.podman}/bin/podman machine init --rootful 2>/dev/null || true
+        ${pkgs.podman}/bin/podman machine set --rootful 2>/dev/null || true
         ${pkgs.podman}/bin/podman machine start 2>/dev/null || true
+        # Cache the DOCKER_HOST socket path for shell startup
+        mkdir -p "$HOME/.local/share/podman"
+        _podman_sock="$(${pkgs.podman}/bin/podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanPipePath}}' 2>/dev/null | tr -d '\n')"
+        if [ -n "$_podman_sock" ]; then
+          echo "unix://$_podman_sock" > "$HOME/.local/share/podman/docker-host"
+        fi
+        unset _podman_sock
       fi
     ''
   );

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -278,13 +278,14 @@ in
     fi
   '';
 
-  # Initialize podman VM for Docker compatibility on lite macOS desktops.
-  # Idempotent: podman machine init fails silently if a machine already exists.
+  # Initialize and start podman VM for Docker compatibility on lite macOS desktops.
+  # Idempotent: podman machine init/start are no-ops if machine already exists/running.
   home.activation.initPodmanMachine = lib.hm.dag.entryAfter [ "writeBoundary" ] (
     lib.optionalString (isDesktop && lite && pkgs.stdenv.isDarwin) ''
-      echo "==> Initializing podman VM (lite macOS desktop)..."
+      echo "==> Initializing podman VM (lite macOS desktop)…"
       if command -v podman >/dev/null 2>&1; then
         ${pkgs.podman}/bin/podman machine init 2>/dev/null || true
+        ${pkgs.podman}/bin/podman machine start 2>/dev/null || true
       fi
     ''
   );

--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -69,6 +69,16 @@ $env.NDK_HOME = if ($ndk_base | path exists) {
 # ---------------------------------------------------------------------------
 $env.PNPM_HOME = $"($env.HOME)/Library/pnpm"
 # ---------------------------------------------------------------------------
+# Docker compatibility via podman (macOS)
+# ---------------------------------------------------------------------------
+# Set DOCKER_HOST from podman machine socket path cached by activation/launchd.
+# This enables Docker SDK clients (docker-py, Testcontainers, etc.) to connect
+# to the podman VM. The `docker` CLI alias (podman) works without this.
+let _podman_docker_host = $"($env.HOME)/.local/share/podman/docker-host"
+if ($"(_podman_docker_host)" | path exists) {
+    $env.DOCKER_HOST = (open $"(_podman_docker_host)" --raw | str trim)
+}
+# ---------------------------------------------------------------------------
 # GPG
 # ---------------------------------------------------------------------------
 $env.GPG_TTY = (try { tty } catch { "" })

--- a/Configs/shell/.config/shell/env.sh
+++ b/Configs/shell/.config/shell/env.sh
@@ -65,6 +65,18 @@ unset _ndk_base
 export PNPM_HOME="$HOME/Library/pnpm"
 
 # ---------------------------------------------------------------------------
+# Docker compatibility via podman (macOS)
+# ---------------------------------------------------------------------------
+# Set DOCKER_HOST from podman machine socket path cached by activation/launchd.
+# This enables Docker SDK clients (docker-py, Testcontainers, etc.) to connect
+# to the podman VM. The `docker` CLI wrapper (exec podman) works without this.
+if [ -f "$HOME/.local/share/podman/docker-host" ]; then
+	_docker_host="$(cat "$HOME/.local/share/podman/docker-host")"
+	[ -n "$_docker_host" ] && export DOCKER_HOST="$_docker_host"
+	unset _docker_host
+fi
+
+# ---------------------------------------------------------------------------
 # GPG
 # ---------------------------------------------------------------------------
 GPG_TTY=$(tty 2>/dev/null || true)


### PR DESCRIPTION
## Summary
- Init podman machine with `--rootful` for better Docker compatibility (privileged ports, etc.)
- Run `podman machine set --rootful` for existing machines
- Add `podman machine start` to home-manager activation (was only `init` before)
- Add launchd agent to auto-start podman VM on login for lite desktop Macs
- Cache `DOCKER_HOST` socket path after podman machine starts
- Set `DOCKER_HOST` in POSIX and Nushell shell env from the cache file

This fixes the "docker daemon not running" error on Mac Minis in lite mode. The previous setup only ran `podman machine init` but never `start`, and didn't set `DOCKER_HOST` for Docker SDK clients.

After deploying, run on existing minis:
```bash
podman machine set --rootful
podman machine start
```
Then `rebuild` to pick up the new config.

## Verification
- `dprint check --config Configs/dprint/dprint.json`
- `shellcheck` passes
- `nix flake check ./Configs/nix/.config/nix --impure --no-build`
- `nu` syntax check passes
