### PR TITLE
fix(nushell): use variable directly for podman docker-host path

### DIFF
--- a/Configs/nushell/.config/nushell/config.nu
+++ b/Configs/nushell/.config/nushell/config.nu
@@ -54,7 +54,8 @@ $env.config = {
                     # Directory stack — push current directory, deduplicate, cap at 10.
                     # Mirrors zsh auto_pushd behaviour used by oh-my-zsh's `d` command.
                     let dir = ($env.PWD | path expand)
-                    $env.DIRSTACK = ([$dir] | append ($env.DIRSTACK | where { $in != $dir }) | first 10)
+                    let stack = ($env | get -o DIRSTACK | default [])
+                    $env.DIRSTACK = ([$dir] | append ($stack | where { $in != $dir }) | first 10)
                 }
             ]
         }
@@ -446,7 +447,9 @@ def c [...paths: string] {
 # `d` shows recent directories numbered 0-9 (0 is current directory).
 # `d <n>` jumps to directory at that index.
 def --env d [index?: int] {
-    let dirs = $env.DIRSTACK
+    let dirs = ($env | get -o DIRSTACK | default [
+        $env.PWD
+    ])
     if ($index != null) {
         if $index >= 0 and $index < ($dirs | length) { cd ($dirs | get $index) } else { print $"(ansi red)Invalid index:(ansi reset) ($index) \(0-($dirs | length | $in - 1)\)" }
         return

--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -75,8 +75,8 @@ $env.PNPM_HOME = $"($env.HOME)/Library/pnpm"
 # This enables Docker SDK clients (docker-py, Testcontainers, etc.) to connect
 # to the podman VM. The `docker` CLI alias (podman) works without this.
 let _podman_docker_host = $"($env.HOME)/.local/share/podman/docker-host"
-if ($"(_podman_docker_host)" | path exists) {
-    $env.DOCKER_HOST = (open $"(_podman_docker_host)" --raw | str trim)
+if ($_podman_docker_host | path exists) {
+    $env.DOCKER_HOST = (open $_podman_docker_host --raw | str trim)
 }
 # ---------------------------------------------------------------------------
 # GPG


### PR DESCRIPTION
## Summary
- Fix Nushell syntax error: `$"(_podman_docker_host)"` was trying to execute the variable as a command instead of referencing it
- Use `$_podman_docker_host` directly instead of wrapping in string interpolation
- Fix DIRSTACK column-not-found error on shell startup by defaulting to empty list when not yet initialized

Both errors appeared after the podman VM auto-start PR (#151).
