### PR TITLE
fix(nix): use stable symlink for DOCKER_HOST across reboots

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -179,7 +179,7 @@
   # Auto-start the podman VM on login for lite desktop Macs.
   # Without this, `docker` (podman wrapper) fails with "daemon not running".
   # `podman machine start` is idempotent — exits cleanly if already running.
-  # After starting, caches the DOCKER_HOST socket path for shell startup.
+  # After starting, creates a stable symlink at ~/.local/share/podman/docker.sock.
   launchd.agents.podman-machine = lib.mkIf (isDesktop && lite) {
     path = [ pkgs.podman ];
     serviceConfig = {
@@ -190,7 +190,7 @@
           "${pkgs.podman}/bin/podman machine start 2>/dev/null || true; "
           + "mkdir -p $HOME/.local/share/podman; "
           + "_sock=$(${pkgs.podman}/bin/podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanPipePath}}' 2>/dev/null | tr -d '\\n'); "
-          + "[ -n \"$_sock\" ] && echo \"unix://$_sock\" > $HOME/.local/share/podman/docker-host || true"
+          + "[ -n \"$_sock\" ] && [ -S \"$_sock\" ] && ln -sf \"$_sock\" $HOME/.local/share/podman/docker.sock || true"
         )
       ];
       RunAtLoad = true;

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -281,6 +281,8 @@ in
   # Initialize and start podman VM for Docker compatibility on lite macOS desktops.
   # Idempotent: podman machine init/start are no-ops if machine already exists/running.
   # --rootful enables root-level container capabilities (ports <1024, etc.).
+  # Creates a stable symlink at ~/.local/share/podman/docker.sock pointing to the
+  # real socket so DOCKER_HOST can use a fixed path across reboots.
   home.activation.initPodmanMachine = lib.hm.dag.entryAfter [ "writeBoundary" ] (
     lib.optionalString (isDesktop && lite && pkgs.stdenv.isDarwin) ''
       echo "==> Initializing rootful podman VM (lite macOS desktop)…"
@@ -288,11 +290,12 @@ in
         ${pkgs.podman}/bin/podman machine init --rootful 2>/dev/null || true
         ${pkgs.podman}/bin/podman machine set --rootful 2>/dev/null || true
         ${pkgs.podman}/bin/podman machine start 2>/dev/null || true
-        # Cache the DOCKER_HOST socket path for shell startup
+        # Create a stable symlink for DOCKER_HOST
         mkdir -p "$HOME/.local/share/podman"
         _podman_sock="$(${pkgs.podman}/bin/podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanPipePath}}' 2>/dev/null | tr -d '\n')"
-        if [ -n "$_podman_sock" ]; then
-          echo "unix://$_podman_sock" > "$HOME/.local/share/podman/docker-host"
+        if [ -n "$_podman_sock" ] && [ -S "$_podman_sock" ]; then
+          ln -sf "$_podman_sock" "$HOME/.local/share/podman/docker.sock"
+          echo "unix://$HOME/.local/share/podman/docker.sock" > "$HOME/.local/share/podman/docker-host"
         fi
         unset _podman_sock
       fi

--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -71,12 +71,12 @@ $env.PNPM_HOME = $"($env.HOME)/Library/pnpm"
 # ---------------------------------------------------------------------------
 # Docker compatibility via podman (macOS)
 # ---------------------------------------------------------------------------
-# Set DOCKER_HOST from podman machine socket path cached by activation/launchd.
-# This enables Docker SDK clients (docker-py, Testcontainers, etc.) to connect
-# to the podman VM. The `docker` CLI alias (podman) works without this.
-let _podman_docker_host = $"($env.HOME)/.local/share/podman/docker-host"
-if ($_podman_docker_host | path exists) {
-    $env.DOCKER_HOST = (open $_podman_docker_host --raw | str trim)
+# Set DOCKER_HOST to the stable podman socket symlink.
+# The symlink is created/updated by home-manager activation and the launchd agent
+# on every login, so DOCKER_HOST can be a fixed path across reboots.
+let _podman_sock = $"($env.HOME)/.local/share/podman/docker.sock"
+if ($_podman_sock | path exists) {
+    $env.DOCKER_HOST = $"unix://($_podman_sock)"
 }
 # ---------------------------------------------------------------------------
 # GPG

--- a/Configs/shell/.config/shell/env.sh
+++ b/Configs/shell/.config/shell/env.sh
@@ -67,13 +67,11 @@ export PNPM_HOME="$HOME/Library/pnpm"
 # ---------------------------------------------------------------------------
 # Docker compatibility via podman (macOS)
 # ---------------------------------------------------------------------------
-# Set DOCKER_HOST from podman machine socket path cached by activation/launchd.
-# This enables Docker SDK clients (docker-py, Testcontainers, etc.) to connect
-# to the podman VM. The `docker` CLI wrapper (exec podman) works without this.
-if [ -f "$HOME/.local/share/podman/docker-host" ]; then
-	_docker_host="$(cat "$HOME/.local/share/podman/docker-host")"
-	[ -n "$_docker_host" ] && export DOCKER_HOST="$_docker_host"
-	unset _docker_host
+# Set DOCKER_HOST to the stable podman socket symlink.
+# The symlink is created/updated by home-manager activation and the launchd agent
+# on every login, so DOCKER_HOST can be a fixed path across reboots.
+if [ -S "$HOME/.local/share/podman/docker.sock" ]; then
+	export DOCKER_HOST="unix://$HOME/.local/share/podman/docker.sock"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
PR #151 cached the podman socket path to a file, but the macOS tmpdir socket path changes across reboots, making the cache stale.

This PR replaces the cache file approach with a **stable symlink**:

- `~/.local/share/podman/docker.sock` → symlink to the real podman socket
- `DOCKER_HOST=unix://$HOME/.local/share/podman/docker.sock` — fixed path that never changes
- Both activation and launchd agent update the symlink on every start
- Shell env only sets `DOCKER_HOST` if the symlink target exists (socket check)

IronClaw and other Docker SDK clients will automatically find the podman VM on every login.

## Verification
- `dprint check`
- `shellcheck`
- `nix flake check`
- `nu` syntax check passes