### PR TITLE
fix: make tuckr:reload --force auto-accept all prompts

### DIFF
--- a/Configs/scripts/.local/bin/tuckr:reload
+++ b/Configs/scripts/.local/bin/tuckr:reload
@@ -29,7 +29,7 @@ def matches_platform [group: string] {
 
 def main [
     --help (-h)     # Show this help message and exit
-    --force         # Pass --force to tuckr (overwrite existing files)
+    --force         # Overwrite existing files and auto-accept all prompts
     --dry-run       # Print what would happen without changing files
 ] {
     let tuckr_location = (detect_tuckr_location)
@@ -93,7 +93,7 @@ def main [
     # Build tuckr args
     let tuckr_args = []
     let tuckr_args = if $dry_run { $tuckr_args | append "--dry-run" } else { $tuckr_args }
-    let tuckr_args = if $force { $tuckr_args | append "--force" } else { $tuckr_args }
+    let tuckr_args = if $force { $tuckr_args | append "--force" | append "--assume-yes" } else { $tuckr_args }
 
     # Determine if a group uses hooks
     def is_hook_group [group: string] {


### PR DESCRIPTION
When `tuckr:reload --force` is used, it currently passes `--force` to `tuckr add`/`tuckr set` but still prompts for confirmation on each group. This adds `--assume-yes` alongside `--force` so the force flag truly makes the command non-interactive.

**Change:**
- `tuckr:reload --force` now passes both `--force` and `--assume-yes` to tuckr
- Updated help text for `--force` to reflect the new behavior