### PR TITLE
fix(nushell): use string concat for DOCKER_HOST interpolation

### DIFF
--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -77,7 +77,7 @@ $env.PNPM_HOME = $"($env.HOME)/Library/pnpm"
 if ($nu.os-info.name == "macos") and (which podman | is-not-empty) {
     let _docker_sock = (do -i { podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanSocket.Path}}' } | str trim)
     if ($_docker_sock | path exists) {
-        $env.DOCKER_HOST = $"unix://(_docker_sock)"
+        $env.DOCKER_HOST = "unix://" + $_docker_sock
     }
 }
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
PR #156 used `$"unix://(_docker_sock)"` inside Nushell, which tries to execute `_docker_sock` as a command instead of interpolating it. This caused a shell startup error on the Mac Minis:

```
Error: nu::shell::external_command
  × External command failed
    ╰── Command `_docker_sock` not found
```

Fix: use string concatenation `"unix://" + $_docker_sock` instead.

Verified on mini02:
- `DOCKER_HOST=unix:///tmp/podman/podman-machine-default-api.sock` is set correctly
- `docker ps` works
- Shell login succeeds without errors

## Verification
- `dprint check`
- `nu --no-config-file -c 'source env.nu'` passes
- Tested on mini02 via SSH
