### PR TITLE
feat(ironclaw): switch database backend from postgres to libsql

### DIFF
--- a/Configs/ironclaw/.ironclaw/.env.base
+++ b/Configs/ironclaw/.ironclaw/.env.base
@@ -1,10 +1,9 @@
 # Ironclaw base configuration — non-secret defaults only.
-# Merged into ~/.ironclaw on deploy; secret values are preserved.
-# Edit secrets directly in ~/.ironclaw (not tracked by git).
+# Merged into ~/.ironclaw/.env on deploy; secret values are preserved.
+# Edit secrets directly in ~/.ironclaw/.env (not tracked by git).
 
-DATABASE_URL=postgres://ifiokjr@localhost/ironclaw
-DATABASE_BACKEND=postgres
-DATABASE_POOL_SIZE=10
+DATABASE_BACKEND=libsql
+LIBSQL_PATH=~/.ironclaw/ironclaw.db
 IRONCLAW_PROFILE=local
 
 LLM_BACKEND=ollama


### PR DESCRIPTION
Switches the ironclaw database backend from PostgreSQL to libSQL.

## Why
PostgreSQL requires a running daemon, which created the persistent `Database backend: PostgreSQL connection failed` error on machines without Postgres. libSQL is an embedded SQLite-compatible database — zero infrastructure needed.

## Changes
- `DATABASE_BACKEND=postgres` → `DATABASE_BACKEND=libsql`
- Added `LIBSQL_PATH=~/.ironclaw/ironclaw.db` (local file, no server)
- Removed `DATABASE_URL` and `DATABASE_POOL_SIZE` (postgres-specific)
- Updated comment to reference `~/.ironclaw/.env` path

## Benefits
- **Zero-setup**: no Postgres daemon needed, database created automatically
- **Portable**: copy `~/.ironclaw/ironclaw.db` to migrate between machines
- **Simpler**: eliminates DB connection failure from `ironclaw doctor`