### PR TITLE
feat: add rebuild --add-preset/--remove-preset for machine presets

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -7,6 +7,7 @@
   lite ? false,
   isDesktop ? false,
   alwaysOn ? false,
+  presets ? [ ],
   ifiokjr-nixpkgs,
   homebrew-core,
   homebrew-cask,

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -4,6 +4,7 @@
   lite ? false,
   isDesktop ? false,
   alwaysOn ? false,
+  presets ? [ ],
   ifiokjr-nixpkgs,
   ...
 }:

--- a/Configs/nix/.config/nix/machine.nix.example
+++ b/Configs/nix/.config/nix/machine.nix.example
@@ -25,4 +25,9 @@
   # enables the screensaver (Aerial/Grounds) with password lock.
   # Intended for always-plugged-in desktops and servers.
   alwaysOn = false;
+
+  # Optional: Machine presets — enables feature sets for specific use cases.
+  # Use `rebuild --add-preset <name>` or `rebuild --remove-preset <name>` to manage.
+  # Available presets: ironclaw
+  # presets = [];
 }

--- a/Configs/scripts/.local/bin/nu_modules/nix_config.nu
+++ b/Configs/scripts/.local/bin/nu_modules/nix_config.nu
@@ -91,6 +91,82 @@ export def set-always-on-mode [value: bool, --path(-p): string] {
     }
     $updated | save -f $target_path
 }
+# Known presets and their descriptions.
+# These map to machine.nix `presets` list entries and Nix conditional logic.
+#
+# Adding a new preset:
+#   1. Add it here with a description
+#   2. Wire it into home.nix/darwin.nix to conditionally enable features
+#   3. Add tuckr config groups with matching preset membership
+export def known-presets [] { {ironclaw: "Ironclaw agent runtime — enables libSQL database and ironclaw service"} }
+# Add a preset to machine.nix (inserts the presets list if missing, appends if present).
+export def add-preset [preset: string, --path(-p): string] {
+    let preset = ($preset | str downcase)
+    let known = (known-presets)
+    let preset_names = ($known | columns)
+    if $preset not-in $preset_names {
+        error make {
+            msg: $"Unknown preset '($preset)'. Available presets: ($preset_names | str join ', ')"
+        }
+    }
+    let target_path = ($path | default (machine-config-path))
+    if not ($target_path | path exists) {
+        error make {
+            msg: $"machine.nix not found at: ($target_path)"
+        }
+    }
+    let content = (open $target_path --raw)
+    # Parse current presets list (if any)
+    let current_entries = try {
+        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
+        if ($raw | is-empty) { [] } else {
+            $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
+        }
+    } catch { [] }
+    # Already present — no-op
+    if $preset in $current_entries {
+        return
+    }
+    let new_entries = ($current_entries | append $preset | each {|x| $'"($x)"'})
+    let preset_line = $"  presets = [($new_entries | str join ' ')];"
+    let updated = if ($content | str contains 'presets =') {
+        $content | str replace --regex '(?m)^\s*presets\s*=\s*\[[^\]]*\];\s*$' $preset_line
+    } else {
+        let with_presets = $"\n  # Machine presets — determines which feature sets to enable\n($preset_line)\n}"
+        $content | str replace --regex '\n\}\s*$' $with_presets
+    }
+    $updated | save -f $target_path
+}
+# Remove a preset from machine.nix (removes from the list, cleans up empty list).
+export def remove-preset [preset: string, --path(-p): string] {
+    let preset = ($preset | str trim | str downcase)
+    let target_path = ($path | default (machine-config-path))
+    if not ($target_path | path exists) {
+        error make {
+            msg: $"machine.nix not found at: ($target_path)"
+        }
+    }
+    let content = (open $target_path --raw)
+    if not ($content | str contains 'presets =') {
+        return
+    }
+    # Parse current entries and remove the target
+    let current_entries = try {
+        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
+        if ($raw | is-empty) { [] } else {
+            $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
+        }
+    } catch { [] }
+    let new_entries = ($current_entries | where {|x| $x != $preset} | each {|x| $'"($x)"'})
+    let updated = if ($new_entries | length) > 0 {
+        let preset_line = $"  presets = [($new_entries | str join ' ')];"
+        $content | str replace --regex '(?m)^\s*presets\s*=\s*\[[^\]]*\];\s*$' $preset_line
+    } else {
+        # Remove the presets line entirely (and its comment)
+        $content | str replace --regex '(?m)^[ \t]*#\s*Machine presets.*\n?[ \t]*presets\s*=\s*\[\s*\];\s*\n?' ''
+    }
+    $updated | save -f $target_path
+}
 # Parse machine.nix and return {username, system, hostname} record.
 # machine.nix is a simple Nix attrset (not a module), so we extract
 # values with regex rather than invoking the nix evaluator.
@@ -115,6 +191,13 @@ export def parse-machine-config [] {
     let isDesktop = try { (($content | parse --regex 'isDesktop\s*=\s*(true|false);' | get capture0.0) == "true") } catch { false }
     # alwaysOn is optional — older machine.nix files may not have it
     let alwaysOn = try { (($content | parse --regex 'alwaysOn\s*=\s*(true|false);' | get capture0.0) == "true") } catch { false }
+    # presets is optional — a quoted list inside brackets
+    let presets = try {
+        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
+        if ($raw | is-empty) { [] } else {
+            $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
+        }
+    } catch { [] }
     {
         username: $username
         system: $system
@@ -122,5 +205,6 @@ export def parse-machine-config [] {
         lite: $lite
         isDesktop: $isDesktop
         alwaysOn: $alwaysOn
+        presets: $presets
     }
 }

--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -116,6 +116,8 @@ def main [
     --rebuild-os   # Install all available macOS software updates before rebuilding (slow)
     --always-on    # Set machine.nix alwaysOn = true (never sleep, screensaver with lock)
     --no-always-on # Set machine.nix alwaysOn = false
+    --add-preset: string  # Add a preset to machine.nix (e.g. ironclaw)
+    --remove-preset: string  # Remove a preset from machine.nix
 ] {
     if $force and not $latest {
         err "--force requires --latest"
@@ -140,6 +142,18 @@ def main [
     if $brew and not $update {
         err "--brew requires --update"
         exit 1
+    }
+
+    # Handle --add-preset: add a preset to machine.nix
+    if ($add_preset | is-not-empty) {
+        nix_config add-preset $add_preset
+        success $"Added preset '($add_preset)' to machine.nix"
+    }
+
+    # Handle --remove-preset: remove a preset from machine.nix
+    if ($remove_preset | is-not-empty) {
+        nix_config remove-preset $remove_preset
+        success $"Removed preset '($remove_preset)' from machine.nix"
     }
 
     # Register cleanup: restore original branch and stash after --latest.
@@ -338,6 +352,9 @@ def main [
     print $"  System: ($config.system)"
     print $"  Lite: ($config.lite)"
     print $"  Desktop: ($config.isDesktop)"
+    if ($config.presets | is-not-empty) {
+        print $"  Presets: (($config.presets | str join ', '))"
+    }
     print ""
 
     # Rebuild must work even when the user's shell has not loaded Nix yet.


### PR DESCRIPTION
Adds the ability to add and remove machine presets via `rebuild`, enabling feature sets like `ironclaw` to be toggled per-machine.

## Usage

```bash
# Add a preset
rebuild --add-preset ironclaw

# Remove a preset
rebuild --remove-preset ironclaw

# Combine with rebuild
rebuild --add-preset ironclaw --lite
```

## Changes

### nix_config.nu (new functions)
- `known-presets` — returns validated preset names with descriptions
- `add-preset` — adds a preset to `machine.nix`, validates it exists
- `remove-preset` — removes a preset from `machine.nix`
- `parse-machine-config` — now returns a `presets` list field

### rebuild (new flags)
- `--add-preset <name>` — adds a preset to machine.nix before rebuilding
- `--remove-preset <name>` — removes a preset from machine.nix before rebuilding
- Configuration summary now shows current presets

### Nix config
- `home.nix` and `darwin.nix` accept `presets ? []` parameter
- `machine.nix.example` documents the presets field

## Available presets
- `ironclaw` — Ironclaw agent runtime with libSQL database and auto-start service

## Follow-up work (separate PRs)
- Wire `presets` into Nix conditional logic in `home.nix`/ `darwin.nix` (auto-start services, etc.)
- Add the `ironclaw` tuckr config group to the `ironclaw` preset
- Thread `presets` through `flake.nix` specialArgs