### PR TITLE
feat: add pnpmg alias for running pnpm in global folder

### DIFF
--- a/Configs/nushell/.config/nushell/config.nu
+++ b/Configs/nushell/.config/nushell/config.nu
@@ -139,6 +139,7 @@ alias cw = cargo watch -x run
 # pnpm
 alias p = pnpm
 alias pu = pnpm update -g -iL
+alias pnpmg = pnpm --dir ~/.local/share/pnpm-global
 # alias pi = pnpm install
 # alias pd = pnpm dev
 # alias pb = pnpm build

--- a/Configs/shell/.config/shell/env.sh
+++ b/Configs/shell/.config/shell/env.sh
@@ -134,6 +134,12 @@ if [ -f "$HOME/.config/agents/agents.env.sh" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# pnpm global shortcut
+# ---------------------------------------------------------------------------
+# pnpmg runs pnpm in the managed global project directory.
+pnpmg() { pnpm --dir "${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global" "$@"; }
+
+# ---------------------------------------------------------------------------
 # Secrets — 1Password-backed via SecretSpec, no plaintext on disk
 # ---------------------------------------------------------------------------
 if [ -f "$HOME/.config/shell/secrets.sh" ]; then


### PR DESCRIPTION
## Summary
- Add `pnpmg` alias that runs pnpm in the managed global project directory (`~/.local/share/pnpm-global`)
- Nushell: `alias pnpmg = pnpm --dir ~/.local/share/pnpm-global`
- POSIX shell: `pnpmg() { pnpm --dir "${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global" "$@"; }`

This lets you run commands like `pnpmg add typescript` or `pnpmg list` against your global packages.

## Verification
- `dprint check`
- `shellcheck`
- `nu` syntax check passes