### PR TITLE
chore: set default Ollama model to kimi-k2.6:cloud

### DIFF
--- a/Configs/ironclaw/.ironclaw/.env.base
+++ b/Configs/ironclaw/.ironclaw/.env.base
@@ -7,7 +7,7 @@ LIBSQL_PATH=~/.ironclaw/ironclaw.db
 IRONCLAW_PROFILE=local
 
 LLM_BACKEND=ollama
-OLLAMA_MODEL=gemma4:latest
+OLLAMA_MODEL=kimi-k2.6:cloud
 OLLAMA_BASE_URL=http://localhost:11434
 
 AGENT_NAME=ironclaw-mini02


### PR DESCRIPTION
Update the default Ollama model in the ironclaw base config from `gemma4:latest` to `kimi-k2.6:cloud`.