### PR TITLE
feat(helix): auto-install scooter.hx plugin in custom Helix setup

### DIFF
--- a/Configs/scripts/.local/bin/install:helix:custom
+++ b/Configs/scripts/.local/bin/install:helix:custom
@@ -128,7 +128,7 @@ def setup_symlinks [helix_dir: string, helix_bin: string, runtime_src: string, r
     info "You can now run: hx"
 }
 
-# Install forge packages required by init.scm (splash screen, keymaps, etc.)
+# Install forge packages required by init.scm (splash screen, keymaps, scooter, etc.)
 def install_forge_packages [] {
     let forge_bin = $"($env.HOME)/.local/bin/forge"
     if not ($forge_bin | path exists) {
@@ -136,12 +136,21 @@ def install_forge_packages [] {
         return
     }
 
-    info "Installing forge packages..."
-    let result = do -i { ^$forge_bin pkg install --git https://github.com/mattwparas/helix-config.git }
-    if ($env.LAST_EXIT_CODE == 0) {
-        success "Forge packages installed successfully"
-    } else {
-        warn "Failed to install forge packages (you can run 'forge pkg install --git https://github.com/mattwparas/helix-config.git' manually)"
+    # Packages required by the helix config
+    let packages = [
+        [name description url];
+        ["helix-config" "splash screen, keymaps, helix-ext" "https://github.com/mattwparas/helix-config.git"]
+        ["scooter.hx" "interactive find-and-replace" "https://github.com/thomasschafer/scooter.hx.git"]
+    ]
+
+    for pkg in $packages {
+        info $"Installing ($pkg.name) (($pkg.description))..."
+        let result = do -i { ^$forge_bin pkg install --git $pkg.url }
+        if ($env.LAST_EXIT_CODE == 0) {
+            success $"($pkg.name) installed successfully"
+        } else {
+            warn $"Failed to install ($pkg.name) (you can run 'forge pkg install --git ($pkg.url)' manually)"
+        }
     }
 }
 

--- a/lib/setup/deploy.sh
+++ b/lib/setup/deploy.sh
@@ -144,7 +144,8 @@ maybe_install_custom_helix() {
 	print_info "This will:"
 	echo "  • Clone/update the Helix Steel fork (mattwparas/helix)"
 	echo "  • Build Helix with Steel plugin support (requires Rust/cargo)"
-	echo "  • Install Steel language server and package manager"
+	echo "  • Install Steel language server, package manager, and forge plugins"
+	echo "  • Install scooter.hx (interactive find-and-replace plugin)"
 	echo "  • This process takes 5-10 minutes"
 	echo ""
 


### PR DESCRIPTION
## Summary
The Helix config already references scooter.hx in `init.scm` and has keybindings in `config.toml` (`:scooter`, `:scooter-new`), but the plugin was never installed during setup.

### Changes
- **install:helix:custom**: Refactored `install_forge_packages` from a single `forge pkg install` call to a loop over a declarative package table. Added `scooter.hx` as the second entry alongside the existing `helix-config`.
- **deploy.sh**: Updated the setup message to mention scooter.hx installation.

### For existing machines
Run the forge install manually:
```sh
forge pkg install --git https://github.com/thomasschafer/scooter.hx.git
```

Or re-run the full setup: `install:helix:custom`