### PR TITLE
feat(helix): replace gemini/codex/claude with pi, remove serpl, add missing LSPs

### DIFF
--- a/Configs/helix/.config/helix/config.toml
+++ b/Configs/helix/.config/helix/config.toml
@@ -172,31 +172,16 @@ s = ["split_selection_on_newline", ":sort", "merge_selections"]
 f = [":scooter"]
 ## A better finder using scooter
 F = [":scooter-new"]
-## Open find and replace within the helix editor
-r = [
-	":write-all",
-	":new",
-	":insert-output serpl >/dev/tty",
-	":set mouse false",
-	":set mouse true",
-	":buffer-close!",
-	":redraw",
-	":reload-all",
-]
+## Open find and replace using scooter plugin
+r = [":scooter"]
 ## Open Git in a zellij floating pane
 g = ":! zellij run --floating --close-on-exit --name \"git\" -- lazygit"
-## Open gemini in a zellij floating pane
-G = ":! zellij run --floating --close-on-exit --name \"gemini\" -- gemini -m gemini-2.5-flash"
-## Open file finder in a zellij floating pane
-R = ":! zellij run --floating --close-on-exit --name \"find-and-replace\" -- serpl"
 ## Open terminal in a zellij floating pane
 t = ":! zellij run --floating --close-on-exit --name \"quick-terminal\""
 ## Reveal current file in Yazi sidebar
 y = ':sh nu ~/.local/bin/yazi-reveal "%{buffer_name}"'
-## Open Codex AI in a zellij floating pane
-C = ':! zellij run --floating --close-on-exit --name "codex" -- codex'
-## Open Claude Code in a zellij floating pane
-c = ':! zellij run --floating --close-on-exit --name "claude" -- claude'
+## Open Pi AI in a zellij floating pane
+C = ':! zellij run --floating --close-on-exit --name "pi" -- pi'
 
 [keys.normal.ret]
 s = ["split_selection_on_newline", ":sort", "merge_selections"]
@@ -204,31 +189,16 @@ s = ["split_selection_on_newline", ":sort", "merge_selections"]
 f = [":scooter"]
 ## A better finder using scooter
 F = [":scooter-new"]
-## Open find and replace within the helix editor
-r = [
-	":write-all",
-	":new",
-	":insert-output serpl >/dev/tty",
-	":set mouse false",
-	":set mouse true",
-	":buffer-close!",
-	":redraw",
-	":reload-all",
-]
+## Open find and replace using scooter plugin
+r = [":scooter"]
 ## Open Git in a zellij floating pane
 g = ":! zellij run --floating --close-on-exit --name \"git\" -- lazygit"
-## Open gemini in a zellij floating pane
-G = ":! zellij run --floating --close-on-exit --name \"gemini\" -- gemini -m gemini-2.5-flash"
-## Open file finder in a zellij floating pane
-R = ":! zellij run --floating --close-on-exit --name \"find-and-replace\" -- serpl"
 ## Open terminal in a zellij floating pane
 t = ":! zellij run --floating --close-on-exit --name \"quick-terminal\""
 ## Reveal current file in Yazi sidebar
 y = ':sh nu ~/.local/bin/yazi-reveal "%{buffer_name}"'
-## Open Codex AI in a zellij floating pane
-C = ':! zellij run --floating --close-on-exit --name "codex" -- codex'
-## Open Claude Code in a zellij floating pane
-c = ':! zellij run --floating --close-on-exit --name "claude" -- claude'
+## Open Pi AI in a zellij floating pane
+C = ':! zellij run --floating --close-on-exit --name "pi" -- pi'
 
 [keys.normal.ret.b]
 ## Close the current buffer only if saved.

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -104,7 +104,10 @@ in
       bash-language-server
       kotlin-language-server
       lua-language-server
+      lsp-ai
+      ltex-ls
       markdown-oxide
+      nil
       ruby
       ruby-lsp
       sqls
@@ -155,6 +158,7 @@ in
 
       # Custom packages from ifiokjr/nixpkgs
       extra.cargo-interactive-update
+      extra.ccase
       extra.ironclaw
       extra.monochange
       extra.pnpm-11


### PR DESCRIPTION
## Summary

### Helix config changes
- **Replace gemini/codex/claude keybindings** with single `C` keybinding for `pi`
- **Remove serpl** keybindings — scooter (the Helix plugin) is the replacement for find-and-replace
- **Simplify `r` key** from the serpl pipe command to just `:scooter`

### Nix package additions
- **Language Servers** (referenced in languages.toml but missing from packages):
  - `nil` — Nix LSP
  - `lsp-ai` — AI-powered LSP
  - `ltex-ls` — LanguageTool LSP for prose
  - `markdown-oxide` was already present
- **`extra.ccase`** from ifiokjr/nixpkgs — case conversion tool used in `space+backtick` keybindings

### Removed keybindings
- `G` (gemini), `C` (codex), `c` (claude) → replaced with `C` (pi)
- `R` (serpl floating pane) → removed (scooter handles this natively)
- Inline serpl pipe for `r` → replaced with `:scooter`
