### PR TITLE
fix(nix): update ifiokjr/nixpkgs flake lock for ccase package

### DIFF
--- a/Configs/nix/.config/nix/flake.lock
+++ b/Configs/nix/.config/nix/flake.lock
@@ -132,11 +132,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779658978,
-        "narHash": "sha256-1bdPNILwjX4JQIscGOzCTY3cAhY0KCB44GwmlfOqpFk=",
+        "lastModified": 1779788800,
+        "narHash": "sha256-DmT3y1Faw9F4pflCaJ95p4xPwcCfchiMcQfP2imrktQ=",
         "owner": "ifiokjr",
         "repo": "nixpkgs",
-        "rev": "f025f5c51ccbccfdc5ad1f07b0f50056dbfc9997",
+        "rev": "1d492c56ac452af574985d2a4780ce07827e5bd2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The previous PR #166 added `extra.ccase` to home.nix but the pinned ifiokjr/nixpkgs revision didn't include it, causing CI failures on x86\_linux.

Update the flake lock to the latest ifiokjr/nixpkgs revision which includes the ccase package.