### PR TITLE
feat(cli): auto-compile dotfiles binary after nix rebuild

### DIFF
--- a/Configs/scripts/.local/bin/.gitignore
+++ b/Configs/scripts/.local/bin/.gitignore
@@ -1,0 +1,4 @@
+# Compiled binaries — these are built by 'deno compile' and should not be tracked.
+# The 'df' symlink is also generated at build time.
+dotfiles
+df

--- a/Hooks/nix/post.sh
+++ b/Hooks/nix/post.sh
@@ -453,5 +453,42 @@ if [ -n "${GITHUB_ACTIONS:-}" ] && [ -n "${GITHUB_PATH:-}" ]; then
 	fi
 fi
 
+# ---------------------------------------------------------------------------
+# Compile the dotfiles CLI binary after a successful rebuild.
+# This ensures 'dotfiles' and 'df' are always in sync with the source.
+# ---------------------------------------------------------------------------
+if [ "$REBUILD_EXIT" -eq 0 ]; then
+	DOTFILES_REPO_DIR="${DOTFILES_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)}"
+	CLI_DIR="$DOTFILES_REPO_DIR/cli"
+	DOTFILES_BIN="$HOME/.local/bin/dotfiles"
+
+	if [ -d "$CLI_DIR" ] && [ -f "$CLI_DIR/main.ts" ]; then
+		if command -v deno >/dev/null 2>&1; then
+			echo "==> Compiling dotfiles CLI..."
+			if deno compile --allow-all --output "$DOTFILES_BIN" "$CLI_DIR/main.ts" >/dev/null 2>&1; then
+				echo "    dotfiles CLI compiled successfully"
+
+				# Create/update the df symlink
+				DF_BIN="$HOME/.local/bin/df"
+				ln -sf "$DOTFILES_BIN" "$DF_BIN"
+
+				# Verify it works
+				if "$DOTFILES_BIN" version >/dev/null 2>&1; then
+					echo "    dotfiles v$("$DOTFILES_BIN" version 2>/dev/null | head -1) installed at $DOTFILES_BIN"
+				else
+					echo "    WARNING: dotfiles binary compiled but does not run"
+					REBUILD_EXIT=1
+				fi
+			else
+				echo "    WARNING: dotfiles CLI compilation failed (non-fatal)"
+			fi
+		else
+			echo "    Skipping dotfiles CLI compilation (deno not found)"
+		fi
+	else
+		echo "    Skipping dotfiles CLI compilation (no cli/ directory found)"
+	fi
+fi
+
 # Propagate rebuild failure so callers know the rebuild didn't fully succeed.
 exit "$REBUILD_EXIT"


### PR DESCRIPTION
## Summary

After a successful `rebuild`, the nix post-hook now automatically compiles the `dotfiles` CLI binary and installs it to `~/.local/bin/dotfiles` with a `df` symlink alias.

This means `dotfiles -h` and `df -h` will work immediately after any rebuild — no manual install step needed.

## What it does

- At the end of `Hooks/nix/post.sh` (after a successful rebuild):
  1. Compiles the CLI: `deno compile --allow-all --output ~/.local/bin/dotfiles cli/main.ts`
  2. Creates `~/.local/bin/df` -> `dotfiles` symlink
  3. Verifies the binary runs (`dotfiles version`)
- If Deno isn't installed, logs a skip message (non-fatal)
- If the rebuild failed, skips compilation entirely

## Also includes

- `.gitignore` for `Configs/scripts/.local/bin/` to exclude the compiled binary and `df` symlink from version control

## Test plan

1. After merging, run `rebuild` (or the nix post-hook manually)
2. Verify `~/.local/bin/dotfiles` exists and runs
3. Verify `~/.local/bin/df` is a symlink to `dotfiles`
4. Verify `dotfiles -h` shows the help output
5. Verify `df version --verbose` shows version + env info
