### PR TITLE
feat(cli): add groups undeploy, env secrets, and auto-compile after rebuild

### DIFF
--- a/Configs/scripts/.local/bin/.gitignore
+++ b/Configs/scripts/.local/bin/.gitignore
@@ -1,0 +1,4 @@
+# Compiled binaries — these are built by 'deno compile' and should not be tracked.
+# The 'df' symlink is also generated at build time.
+dotfiles
+df

--- a/Hooks/nix/post.sh
+++ b/Hooks/nix/post.sh
@@ -453,5 +453,42 @@ if [ -n "${GITHUB_ACTIONS:-}" ] && [ -n "${GITHUB_PATH:-}" ]; then
 	fi
 fi
 
+# ---------------------------------------------------------------------------
+# Compile the dotfiles CLI binary after a successful rebuild.
+# This ensures 'dotfiles' and 'df' are always in sync with the source.
+# ---------------------------------------------------------------------------
+if [ "$REBUILD_EXIT" -eq 0 ]; then
+	DOTFILES_REPO_DIR="${DOTFILES_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)}"
+	CLI_DIR="$DOTFILES_REPO_DIR/cli"
+	DOTFILES_BIN="$HOME/.local/bin/dotfiles"
+
+	if [ -d "$CLI_DIR" ] && [ -f "$CLI_DIR/main.ts" ]; then
+		if command -v deno >/dev/null 2>&1; then
+			echo "==> Compiling dotfiles CLI..."
+			if deno compile --allow-all --output "$DOTFILES_BIN" "$CLI_DIR/main.ts" >/dev/null 2>&1; then
+				echo "    dotfiles CLI compiled successfully"
+
+				# Create/update the df symlink
+				DF_BIN="$HOME/.local/bin/df"
+				ln -sf "$DOTFILES_BIN" "$DF_BIN"
+
+				# Verify it works
+				if "$DOTFILES_BIN" version >/dev/null 2>&1; then
+					echo "    dotfiles v$("$DOTFILES_BIN" version 2>/dev/null | head -1) installed at $DOTFILES_BIN"
+				else
+					echo "    WARNING: dotfiles binary compiled but does not run"
+					REBUILD_EXIT=1
+				fi
+			else
+				echo "    WARNING: dotfiles CLI compilation failed (non-fatal)"
+			fi
+		else
+			echo "    Skipping dotfiles CLI compilation (deno not found)"
+		fi
+	else
+		echo "    Skipping dotfiles CLI compilation (no cli/ directory found)"
+	fi
+fi
+
 # Propagate rebuild failure so callers know the rebuild didn't fully succeed.
 exit "$REBUILD_EXIT"

--- a/cli/commands/env.ts
+++ b/cli/commands/env.ts
@@ -1,9 +1,19 @@
 /**
  * `dotfiles env` — Environment management
+ *
+ * Provides subcommands for managing environment setup and secrets.
+ * `env setup` runs the setup:env script.
+ * `env secrets` delegates to SecretSpec CLI for checking, running,
+ * and managing secrets.
  */
 
 import { Command } from "@cliffy/command";
-import { resolveDotfilesDir, runCommand } from "../lib/config.ts";
+import {
+	printError,
+	printSuccess,
+	resolveDotfilesDir,
+	runCommand,
+} from "../lib/config.ts";
 
 export const envCommand = new Command()
 	.description("Manage environment configuration and secrets")
@@ -19,4 +29,89 @@ export const envCommand = new Command()
 				});
 				if (!success) Deno.exit(code);
 			}),
+	)
+	.command(
+		"secrets",
+		new Command()
+			.description("Manage secrets via SecretSpec")
+			.command(
+				"check",
+				new Command()
+					.description("Check if all required secrets are available")
+					.action(async () => {
+						const dotfilesDir = await resolveDotfilesDir();
+						const specFile =
+							`${dotfilesDir}/Configs/secretspec/secretspec.toml`;
+						const { code, success } = await runCommand(
+							["secretspec", "check", "-f", specFile],
+							{ cwd: dotfilesDir },
+						);
+						if (!success) {
+							printError(`Secret check failed (exit ${code})`);
+							Deno.exit(code);
+						}
+						printSuccess("All required secrets are available");
+					}),
+			)
+			.command(
+				"run",
+				new Command()
+					.description(
+						"Run a command with secrets injected into the environment",
+					)
+					.arguments("<command...:string>")
+					.option(
+						"--include <secrets...:string>",
+						"Only include specific secrets (comma-separated or repeated)",
+					)
+					.action(async (opts, ...command: string[]) => {
+						const dotfilesDir = await resolveDotfilesDir();
+						const specFile =
+							`${dotfilesDir}/Configs/secretspec/secretspec.toml`;
+						const args = ["secretspec", "run", "-f", specFile];
+						if (opts.include?.length) {
+							for (const inc of opts.include) {
+								args.push("--include", inc);
+							}
+						}
+						args.push("--", ...command);
+
+						const { code, success } = await runCommand(args, {
+							cwd: dotfilesDir,
+						});
+						if (!success) Deno.exit(code);
+					}),
+			)
+			.command(
+				"get",
+				new Command()
+					.description("Get a specific secret value")
+					.arguments("<name:string>")
+					.action(async (_opts, name: string) => {
+						const dotfilesDir = await resolveDotfilesDir();
+						const specFile =
+							`${dotfilesDir}/Configs/secretspec/secretspec.toml`;
+						const { code, success } = await runCommand(
+							["secretspec", "get", "-f", specFile, name],
+							{ cwd: dotfilesDir },
+						);
+						if (!success) Deno.exit(code);
+					}),
+			)
+			.command(
+				"set",
+				new Command()
+					.description("Set a specific secret value")
+					.arguments("<name:string>")
+					.action(async (_opts, name: string) => {
+						const dotfilesDir = await resolveDotfilesDir();
+						const specFile =
+							`${dotfilesDir}/Configs/secretspec/secretspec.toml`;
+						const { code, success } = await runCommand(
+							["secretspec", "set", "-f", specFile, name],
+							{ cwd: dotfilesDir },
+						);
+						if (!success) Deno.exit(code);
+					}),
+			),
 	);

--- a/cli/commands/groups.ts
+++ b/cli/commands/groups.ts
@@ -103,6 +103,40 @@ export const groupsCommand = new Command()
 			}),
 	)
 	.command(
+		"undeploy",
+		new Command()
+			.description("Remove configuration groups and run cleanup hooks")
+			.arguments("<groups...:string>")
+			.option("--no-hooks", "Skip running cleanup hooks (only remove symlinks)")
+			.action(async (opts, ...groups: string[]) => {
+				const dotfilesDir = await resolveDotfilesDir();
+
+				const knownGroups = await discoverGroups(dotfilesDir);
+				for (const group of groups) {
+					if (!knownGroups.includes(group)) {
+						printError(`Unknown configuration group: ${group}`);
+						console.log(`Available groups: ${knownGroups.join(", ")}`);
+						Deno.exit(1);
+					}
+				}
+
+				const subcommand = opts.hooks ? "unset" : "rm";
+				const args = ["tuckr", subcommand, ...groups];
+
+				const { code, success } = await runCommand(args, {
+					cwd: dotfilesDir,
+				});
+
+				if (!success) {
+					printError(`Undeploy failed with exit code ${code}`);
+					Deno.exit(code);
+				}
+
+				const action = opts.hooks ? "Undeployed" : "Removed symlinks for";
+				printSuccess(`${action} groups: ${groups.join(", ")}`);
+			}),
+	)
+	.command(
 		"status",
 		new Command()
 			.description("Show deployment status of all groups")


### PR DESCRIPTION
## Summary

Completes Phase 1 CLI coverage with three additions:

### 1. `dotfiles groups undeploy <groups...>`
Remove config groups via `tuckr unset` (runs cleanup hooks) or `tuckr rm` (with `--no-hooks`, symlinks only). Validates group names before delegating.

### 2. `dotfiles env secrets` — SecretSpec integration
Manage secrets via the SecretSpec CLI with subcommands:
- `env secrets check` — verify all required secrets are available
- `env secrets run <cmd>` — run a command with secrets injected
- `env secrets get <name>` — retrieve a specific secret value
- `env secrets set <name>` — set a specific secret value

### 3. Nix post-hook CLI auto-compile
After a successful rebuild, the nix post-hook automatically compiles and installs the `dotfiles` CLI binary to `~/.local/bin/dotfiles` with a `df` symlink alias.

### 4. `.gitignore` for compiled binaries
Excludes `dotfiles` and `df` from version control.

## Test plan

- [x] `deno task check:all` passes
- [x] `dprint check` and `shellcheck` pass
- [x] `deno task compile:dev` produces working binary
- [x] `dotfiles groups undeploy --help` and `dotfiles env secrets --help` work
- [ ] After merge, run `rebuild` and verify `dotfiles -h` works
