### PR TITLE
fix(ironclaw): enable gateway defaults

### DIFF
--- a/Configs/ironclaw/.ironclaw/.env.base
+++ b/Configs/ironclaw/.ironclaw/.env.base
@@ -4,7 +4,7 @@
 
 DATABASE_BACKEND=libsql
 LIBSQL_PATH=~/.ironclaw/ironclaw.db
-IRONCLAW_PROFILE=local
+# Keep IRONCLAW_PROFILE unset: the built-in local profile disables the web gateway.
 
 LLM_BACKEND=ollama
 OLLAMA_MODEL=kimi-k2.6:cloud
@@ -24,12 +24,14 @@ SELF_REPAIR_MAX_ATTEMPTS=3
 SANDBOX_ENABLED=true
 SANDBOX_POLICY=readonly
 
-HTTP_HOST=0.0.0.0
-HTTP_PORT=43210
-HTTP_ENABLED=true
+# Web Gateway (browser UI) on the tailnet-only service port.
 GATEWAY_HOST=0.0.0.0
 GATEWAY_PORT=43210
 GATEWAY_ENABLED=true
+CLI_ENABLED=true
+
+# Disable the webhook-only HTTP channel; it serves /health only, not the browser UI.
+HTTP_ENABLED=false
 
 RUST_LOG=ironclaw=info
 

--- a/Hooks/ironclaw/post.sh
+++ b/Hooks/ironclaw/post.sh
@@ -45,6 +45,10 @@ else
 	# Start with the existing file (preserves secret-only keys and comments)
 	cp "$IRONCLAW_FILE" "$TEMP_FILE"
 
+	# Remove the old local profile default because it disables the web gateway.
+	sed -i.bak '/^IRONCLAW_PROFILE=local$/d' "$TEMP_FILE"
+	rm -f "$TEMP_FILE.bak"
+
 	# For each KEY=VALUE line in the base file, update or append in the temp file
 	while IFS= read -r line; do
 		# Skip comments and blank lines

--- a/docs/agents/ironclaw-setup.md
+++ b/docs/agents/ironclaw-setup.md
@@ -13,7 +13,7 @@ This documents the setup of IronClaw across your Mac (primary) and three Mac Min
 │  │ ifiokjr     │  │ mini01   │  │ mini02   │  │ mini03   │ │
 │  │ IronClaw    │  │ IronClaw │  │ IronClaw │  │ IronClaw │ │
 │  │ PG :5432    │  │ PG :5432 │  │ PG :5432 │  │ PG :5432 │ │
-│  │ Gateway:3000│  │ :3000    │  │ :3000    │  │ :3000    │ │
+│  │Gateway:43210│  │ :43210   │  │ :43210   │  │ :43210   │ │
 │  │ Ollama      │  │ Ollama   │  │ Ollama   │  │ Ollama   │ │
 │  └─────────────┘  └──────────┘  └──────────┘  └──────────┘ │
 │         │              │             │             │        │
@@ -87,7 +87,6 @@ Created `~/.ironclaw/.env`:
 DATABASE_URL=postgres://ifiokjr@localhost/ironclaw
 DATABASE_BACKEND=postgres
 DATABASE_POOL_SIZE=10
-IRONCLAW_PROFILE=local
 
 # ─── LLM Provider (Ollama - local, private) ───
 LLM_BACKEND=ollama
@@ -113,8 +112,11 @@ SANDBOX_ENABLED=true
 SANDBOX_POLICY=readonly
 
 # ─── Web Gateway (listen on all interfaces for Tailscale) ───
-HTTP_HOST=0.0.0.0
-HTTP_PORT=3000
+GATEWAY_HOST=0.0.0.0
+GATEWAY_PORT=43210
+GATEWAY_ENABLED=true
+CLI_ENABLED=true
+HTTP_ENABLED=false
 
 # ─── Logging ───
 RUST_LOG=ironclaw=info
@@ -170,13 +172,13 @@ ironclaw doctor
 # Expected output:
 #   ✓ LLM configuration   backend=ollama, model=gemma4:latest
 #   ✓ Database backend    PostgreSQL connected
-#   ✓ Gateway config      enabled at 0.0.0.0:3000
+#   ✓ Gateway config      enabled at 0.0.0.0:43210
 #   ✓ Docker daemon       running
 #   ✓ tailscale            1.98.0
 #   ✓ Service             launchd plist installed
 
-curl http://localhost:3000/health
-# Expected: {"status":"healthy","channel":"http"}
+curl http://localhost:43210/api/health
+# Expected: {"status":"healthy","channel":"gateway"}
 ```
 
 ---
@@ -271,7 +273,6 @@ cat > ~/.ironclaw/.env << 'ENVEOF'
 DATABASE_URL=postgres://mini01@localhost/ironclaw
 DATABASE_BACKEND=postgres
 DATABASE_POOL_SIZE=10
-IRONCLAW_PROFILE=local
 
 LLM_BACKEND=ollama
 OLLAMA_MODEL=gemma4:latest
@@ -290,8 +291,11 @@ SELF_REPAIR_MAX_ATTEMPTS=3
 SANDBOX_ENABLED=true
 SANDBOX_POLICY=readonly
 
-HTTP_HOST=0.0.0.0
-HTTP_PORT=3000
+GATEWAY_HOST=0.0.0.0
+GATEWAY_PORT=43210
+GATEWAY_ENABLED=true
+CLI_ENABLED=true
+HTTP_ENABLED=false
 
 RUST_LOG=ironclaw=info
 EMBEDDING_ENABLED=false
@@ -318,7 +322,7 @@ ironclaw service start
 
 # Verify
 ironclaw doctor
-curl http://localhost:3000/health
+curl http://localhost:43210/api/health
 ```
 
 ---
@@ -401,10 +405,10 @@ Or: System Settings → General → Sharing → Remote Login → ON
 2. Log in with the same account
 3. Connect to the tailnet VPN
 4. Access IronClaw web gateways in Safari:
-   - `http://macbookpro:3000` (primary)
-   - `http://mini01:3000`
-   - `http://mini02:3000`
-   - `http://mini03:3000`
+   - `http://macbookpro:43210` (primary)
+   - `http://mini01:43210`
+   - `http://mini02:43210`
+   - `http://mini03:43210`
 
 ---
 
@@ -449,7 +453,7 @@ ironclaw service restart
 ironclaw
 
 # Access Web Gateway
-open http://localhost:3000
+open http://localhost:43210
 
 # Update IronClaw
 brew upgrade ironclaw


### PR DESCRIPTION
## Summary
- enable the IronClaw web gateway on port 43210
- keep CLI enabled alongside the gateway
- disable the webhook-only HTTP channel so `/` serves the browser UI
- remove the old local profile default during deploy merges because it disables the gateway
- update IronClaw setup docs for the gateway health route

## Verification
- `dprint check --config Configs/dprint/dprint.json`
- `shellcheck setup setup-tuckr-symlink.sh Hooks/*/post.sh`
- verified mini02 serves `/` and `/api/health` on port 43210 with CLI and gateway enabled
