### PR TITLE
feat(cli): reload --force, help command, dot alias, security audit

### DIFF
--- a/Configs/scripts/.local/bin/.gitignore
+++ b/Configs/scripts/.local/bin/.gitignore
@@ -1,4 +1,4 @@
 # Compiled binaries — these are built by 'deno compile' and should not be tracked.
-# The 'df' symlink is also generated at build time.
+# The 'dot' symlink is also generated at build time.
 dotfiles
-df
+dot

--- a/Hooks/nix/post.sh
+++ b/Hooks/nix/post.sh
@@ -468,9 +468,9 @@ if [ "$REBUILD_EXIT" -eq 0 ]; then
 			if deno compile --allow-all --output "$DOTFILES_BIN" "$CLI_DIR/main.ts" >/dev/null 2>&1; then
 				echo "    dotfiles CLI compiled successfully"
 
-				# Create/update the df symlink
-				DF_BIN="$HOME/.local/bin/df"
-				ln -sf "$DOTFILES_BIN" "$DF_BIN"
+				# Create/update the dot symlink
+				DOT_BIN="$HOME/.local/bin/dot"
+				ln -sf "$DOTFILES_BIN" "$DOT_BIN"
 
 				# Verify it works
 				if "$DOTFILES_BIN" version >/dev/null 2>&1; then

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,6 +2,16 @@
 
 Unified CLI for managing dotfiles — setup, rebuild, reload, doctor, and more.
 
+After a rebuild, the binary is auto-compiled and installed to `~/.local/bin/dotfiles`
+with a `dot` symlink alias for quick access.
+
+```bash
+dotfiles --help          # show all commands
+dot help groups          # detailed help for a subcommand
+dot groups list          # via the shorter alias
+dotfiles reload --force  # force overwrite existing symlinks
+```
+
 ## Quick Start
 
 ```bash
@@ -40,6 +50,15 @@ deno task test
 # Compile the binary (production)
 deno task compile
 ```
+
+## Alias
+
+The `dotfiles` binary also installs a `dot` symlink alias:
+
+- `dotfiles` — full command name
+- `dot` — short alias (~3 chars, doesn't conflict with existing Unix commands like `df`)
+
+Both point to the same compiled binary.
 
 ## Tooling
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,8 +2,7 @@
 
 Unified CLI for managing dotfiles — setup, rebuild, reload, doctor, and more.
 
-After a rebuild, the binary is auto-compiled and installed to `~/.local/bin/dotfiles`
-with a `dot` symlink alias for quick access.
+After a rebuild, the binary is auto-compiled and installed to `~/.local/bin/dotfiles` with a `dot` symlink alias for quick access.
 
 ```bash
 dotfiles --help          # show all commands

--- a/cli/SECURITY.md
+++ b/cli/SECURITY.md
@@ -2,46 +2,35 @@
 
 ## Dependencies
 
-All dependencies are resolved via JSR (Deno's package registry) with integrity
-hashes pinned in `deno.lock`.
+All dependencies are resolved via JSR (Deno's package registry) with integrity hashes pinned in `deno.lock`.
 
 ### Runtime Dependencies
 
-| Package | Version | Source | Risk |
-|---------|---------|--------|------|
-| `@cliffy/command` | 1.1.0 | JSR | Low — mature CLI framework, MIT licensed, maintained by @c4spar |
-| `@cliffy/prompt` | 1.1.0 | JSR | Low — only used for future interactive features |
-| `@std/fs` | 1.0.23 | JSR | Minimal — Deno official stdlib, read/exists/walk |
-| `@std/path` | 1.1.4 | JSR | Minimal — Deno official stdlib, path manipulation |
-| `@std/toml` | 1.0.0 | JSR | Minimal — Deno official stdlib, TOML parsing |
-| `@std/fmt` | 1.0.10 | JSR | Minimal — Deno official stdlib, ANSI colors |
+| Package           | Version | Source | Risk                                                            |
+| ----------------- | ------- | ------ | --------------------------------------------------------------- |
+| `@cliffy/command` | 1.1.0   | JSR    | Low — mature CLI framework, MIT licensed, maintained by @c4spar |
+| `@cliffy/prompt`  | 1.1.0   | JSR    | Low — only used for future interactive features                 |
+| `@std/fs`         | 1.0.23  | JSR    | Minimal — Deno official stdlib, read/exists/walk                |
+| `@std/path`       | 1.1.4   | JSR    | Minimal — Deno official stdlib, path manipulation               |
+| `@std/toml`       | 1.0.0   | JSR    | Minimal — Deno official stdlib, TOML parsing                    |
+| `@std/fmt`        | 1.0.10  | JSR    | Minimal — Deno official stdlib, ANSI colors                     |
 
 ### Dev Dependencies
 
-| Package | Version | Source | Risk |
-|---------|---------|--------|------|
-| `oxlint` | 1.67.0 | npm | Low — linter only, not in compiled binary |
+| Package  | Version | Source | Risk                                      |
+| -------- | ------- | ------ | ----------------------------------------- |
+| `oxlint` | 1.67.0  | npm    | Low — linter only, not in compiled binary |
 
 ### Key Security Points
 
-1. **No network dependencies at runtime.** The compiled binary embeds only local
-   TypeScript files. No code is fetched at runtime.
+1. **No network dependencies at runtime.** The compiled binary embeds only local TypeScript files. No code is fetched at runtime.
 
-2. **Integrity pins.** `deno.lock` pins every JSR module to a SHA-256 integrity
-   hash. Tampering with any dependency would cause a lockfile mismatch.
+2. **Integrity pins.** `deno.lock` pins every JSR module to a SHA-256 integrity hash. Tampering with any dependency would cause a lockfile mismatch.
 
-3. **Small attack surface.** The CLI shells out to existing scripts (tuckr,
-   nushell, secretspec) using `Deno.Command`. It does not accept arbitrary
-   input over the network.
+3. **Small attack surface.** The CLI shells out to existing scripts (tuckr, nushell, secretspec) using `Deno.Command`. It does not accept arbitrary input over the network.
 
-4. **No known CVEs** for any dependency. The Deno runtime CVE-2025-61787
-   (Windows batch file command injection) is fixed in Deno >= 2.2.15; our
-   runtime is 2.8.0.
+4. **No known CVEs** for any dependency. The Deno runtime CVE-2025-61787 (Windows batch file command injection) is fixed in Deno >= 2.2.15; our runtime is 2.8.0.
 
-5. **Deno permissions.** The binary is compiled with `--allow-all`. This is
-   acceptable because the CLI is a local management tool that needs full
-   filesystem access to manage dotfiles. In Phase 2, we should evaluate
-   narrowing permissions.
+5. **Deno permissions.** The binary is compiled with `--allow-all`. This is acceptable because the CLI is a local management tool that needs full filesystem access to manage dotfiles. In Phase 2, we should evaluate narrowing permissions.
 
-6. **oxlint is dev-only.** It runs during `deno task check:all` and CI but is
-   not embedded in the compiled binary.
+6. **oxlint is dev-only.** It runs during `deno task check:all` and CI but is not embedded in the compiled binary.

--- a/cli/SECURITY.md
+++ b/cli/SECURITY.md
@@ -1,0 +1,47 @@
+# CLI Dependency Security Analysis
+
+## Dependencies
+
+All dependencies are resolved via JSR (Deno's package registry) with integrity
+hashes pinned in `deno.lock`.
+
+### Runtime Dependencies
+
+| Package | Version | Source | Risk |
+|---------|---------|--------|------|
+| `@cliffy/command` | 1.1.0 | JSR | Low — mature CLI framework, MIT licensed, maintained by @c4spar |
+| `@cliffy/prompt` | 1.1.0 | JSR | Low — only used for future interactive features |
+| `@std/fs` | 1.0.23 | JSR | Minimal — Deno official stdlib, read/exists/walk |
+| `@std/path` | 1.1.4 | JSR | Minimal — Deno official stdlib, path manipulation |
+| `@std/toml` | 1.0.0 | JSR | Minimal — Deno official stdlib, TOML parsing |
+| `@std/fmt` | 1.0.10 | JSR | Minimal — Deno official stdlib, ANSI colors |
+
+### Dev Dependencies
+
+| Package | Version | Source | Risk |
+|---------|---------|--------|------|
+| `oxlint` | 1.67.0 | npm | Low — linter only, not in compiled binary |
+
+### Key Security Points
+
+1. **No network dependencies at runtime.** The compiled binary embeds only local
+   TypeScript files. No code is fetched at runtime.
+
+2. **Integrity pins.** `deno.lock` pins every JSR module to a SHA-256 integrity
+   hash. Tampering with any dependency would cause a lockfile mismatch.
+
+3. **Small attack surface.** The CLI shells out to existing scripts (tuckr,
+   nushell, secretspec) using `Deno.Command`. It does not accept arbitrary
+   input over the network.
+
+4. **No known CVEs** for any dependency. The Deno runtime CVE-2025-61787
+   (Windows batch file command injection) is fixed in Deno >= 2.2.15; our
+   runtime is 2.8.0.
+
+5. **Deno permissions.** The binary is compiled with `--allow-all`. This is
+   acceptable because the CLI is a local management tool that needs full
+   filesystem access to manage dotfiles. In Phase 2, we should evaluate
+   narrowing permissions.
+
+6. **oxlint is dev-only.** It runs during `deno task check:all` and CI but is
+   not embedded in the compiled binary.

--- a/cli/commands/reload.ts
+++ b/cli/commands/reload.ts
@@ -18,9 +18,15 @@ export const reloadCommand = new Command()
 	.description(
 		"Reload tuckr configuration groups (non-destructive, re-applies symlinks)",
 	)
-	.option("--group <group:string>", "Reload a single group instead of all groups")
+	.option(
+		"--group <group:string>",
+		"Reload a single group instead of all groups",
+	)
 	.option("--force", "Overwrite existing files and auto-accept all prompts")
-	.option("--adopt", "Adopt conflicting files (overwrite repo with system version)")
+	.option(
+		"--adopt",
+		"Adopt conflicting files (overwrite repo with system version)",
+	)
 	.action(async (opts) => {
 		const dotfilesDir = await resolveDotfilesDir();
 

--- a/cli/commands/reload.ts
+++ b/cli/commands/reload.ts
@@ -18,10 +18,9 @@ export const reloadCommand = new Command()
 	.description(
 		"Reload tuckr configuration groups (non-destructive, re-applies symlinks)",
 	)
-	.option(
-		"--group <group:string>",
-		"Reload a single group instead of all groups",
-	)
+	.option("--group <group:string>", "Reload a single group instead of all groups")
+	.option("--force", "Overwrite existing files and auto-accept all prompts")
+	.option("--adopt", "Adopt conflicting files (overwrite repo with system version)")
 	.action(async (opts) => {
 		const dotfilesDir = await resolveDotfilesDir();
 
@@ -33,6 +32,8 @@ export const reloadCommand = new Command()
 		const args: string[] = [];
 
 		if (opts.group) args.push("--group", opts.group);
+		if (opts.force) args.push("--force");
+		if (opts.adopt) args.push("--adopt");
 
 		printHeader("Reloading dotfiles configuration");
 		const { code, success } = await runCommand([script, ...args], {

--- a/cli/main.ts
+++ b/cli/main.ts
@@ -5,6 +5,7 @@
  */
 
 import { Command } from "@cliffy/command";
+import { HelpCommand } from "@cliffy/command/help";
 import { doctorCommand } from "./commands/doctor.ts";
 import { envCommand } from "./commands/env.ts";
 import { groupsCommand } from "./commands/groups.ts";
@@ -39,4 +40,5 @@ await new Command()
 	.command("uninstall", uninstallCommand)
 	.command("reset", resetCommand)
 	.command("version", versionCommand)
+	.command("help", new HelpCommand().global())
 	.parse(Deno.args);


### PR DESCRIPTION
## Summary

Four improvements to the dotfiles CLI:

### 1. `dotfiles reload --force` and `--adopt`
The `reload` command now accepts `--force` (overwrite existing files, auto-accept prompts) and `--adopt` (adopt conflicting files, overwriting repo versions with system versions). Both flags pass through to the `tuckr:reload` nushell script.

### 2. `dotfiles help <command>` now works
Registered `HelpCommand` from `@cliffy/command/help` so `dotfiles help` and `dotfiles help <subcommand>` work as expected. Previously `dotfiles help` would error with "Unknown command".

### 3. `dot` alias instead of `df`
Changed the CLI symlink alias from `df` (which conflicts with the Unix disk-free command) to `dot`. Updated the nix post-hook and `.gitignore` accordingly.

### 4. Security audit (`cli/SECURITY.md`)
Added a dependency security analysis documenting all 6 runtime + 1 dev dependencies. Key findings:
- All deps are integrity-pinned via `deno.lock`
- No runtime network calls — the compiled binary is self-contained
- No known CVEs in any dependency
- Deno runtime CVE-2025-61787 is fixed in 2.8.0 (our version)

## Test plan
- [x] `deno task check:all` passes
- [x] `dprint check` and `shellcheck` pass
- [x] `dotfiles help` shows main help
- [x] `dotfiles help groups` shows groups subcommand help
- [x] `dotfiles reload --help` shows `--force` and `--adopt` flags
- [x] Compile produces working binary
