### PR TITLE
fix(nix): disable home-manager nixpkgs release check

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -24,6 +24,9 @@ in
   # want to update the value, then make sure to first check the Home Manager
   # release notes.
   home.stateVersion = "25.11"; # Please read the comment before changing.
+  # Home Manager master tracks nixpkgs-unstable; the version check is
+  # outdated since there's no 26.11 release branch yet.
+  home.enableNixpkgsReleaseCheck = false;
 
   # The home.packages option allows you to install Nix packages into your
   # environment. These packages are available to your user account.


### PR DESCRIPTION
Home Manager master reports version 26.05 but we use nixpkgs-unstable (26.11). There's no release-26.11 branch yet, and master is fully compatible. Disable the false-positive version mismatch warning.

Combined with PR #170 which already pins home-manager to the master branch.