### PR TITLE
feat(cli): port tuckr:reload logic natively into TypeScript

### DIFF
--- a/cli/commands/reload.ts
+++ b/cli/commands/reload.ts
@@ -1,18 +1,92 @@
 /**
- * `dotfiles reload` — Tuckr reload all groups (non-destructive)
+ * `dotfiles reload` — Reload tuckr configuration groups
  *
- * Phase 1: Shells out to the nushell tuckr:reload script.
- * Phase 2: Will be reimplemented natively to call tuckr directly.
+ * Discovers all config groups, filters by platform, and re-applies symlinks
+ * using `tuckr add` (regular groups) or `tuckr set` (hook groups).
+ *
+ * Reimplements the nushell tuckr:reload script natively in TypeScript for
+ * type safety, discoverability, and proper flag handling.
+ *
+ * Groups are deployed in order: nix first, then regular groups alphabetically,
+ * then late groups (nushell, helix, claude).
  */
 
 import { Command } from "@cliffy/command";
 import {
-	findExecutable,
+	commandExists,
+	detectPlatform,
+	discoverGroups,
 	printError,
 	printHeader,
+	printInfo,
+	printSuccess,
+	printWarning,
 	resolveDotfilesDir,
 	runCommand,
 } from "../lib/config.ts";
+
+/** Groups that have setup/cleanup hooks (tuckr set instead of tuckr add). */
+const HOOK_GROUPS = ["nix", "nushell", "claude"];
+
+/** Groups processed first regardless of alphabetical order. */
+const PRIMARY_GROUPS = ["nix"];
+
+/** Groups processed last regardless of alphabetical order. */
+const LATE_GROUPS = ["nushell", "helix", "claude"];
+
+/** Platform suffixes used by tuckr for platform-specific groups. */
+const PLATFORM_SUFFIXES = ["_macos", "_linux", "_bsd", "_windows"] as const;
+
+/** The platform suffix that matches the current OS. */
+function platformSuffix(): string {
+	switch (detectPlatform()) {
+		case "macos":
+			return "_macos";
+		case "linux":
+			return "_linux";
+		default:
+			return "";
+	}
+}
+
+/** Check if a group name has a platform suffix. */
+function isPlatformGroup(group: string): boolean {
+	return PLATFORM_SUFFIXES.some((suffix) => group.endsWith(suffix));
+}
+
+/** Check if a platform-specific group matches the current platform. */
+function matchesPlatform(group: string): boolean {
+	const suffix = platformSuffix();
+	if (!suffix) return false;
+	return group.endsWith(suffix);
+}
+
+/** Check if a group has setup/cleanup hooks. */
+function isHookGroup(group: string): boolean {
+	return HOOK_GROUPS.includes(group);
+}
+
+/**
+ * Order groups for deployment: primary → regular → late.
+ * Within each bucket, preserve order.
+ */
+function orderGroups(groups: string[]): string[] {
+	const primary = groups.filter((g) => PRIMARY_GROUPS.includes(g));
+	const late = groups.filter((g) => LATE_GROUPS.includes(g));
+	const regular = groups.filter(
+		(g) => !PRIMARY_GROUPS.includes(g) && !LATE_GROUPS.includes(g),
+	);
+	return [...primary, ...regular, ...late];
+}
+
+/** Resolve the tuckr dotfiles directory (platform-specific). */
+function resolveTuckrDir(): string {
+	const home = Deno.env.get("HOME") ?? "~";
+	if (detectPlatform() === "macos") {
+		return `${home}/Library/Application Support/dotfiles`;
+	}
+	return `${home}/.config/dotfiles`;
+}
 
 export const reloadCommand = new Command()
 	.description(
@@ -27,27 +101,104 @@ export const reloadCommand = new Command()
 		"--adopt",
 		"Adopt conflicting files (overwrite repo with system version)",
 	)
+	.option("--dry-run", "Print what would happen without changing files")
 	.action(async (opts) => {
 		const dotfilesDir = await resolveDotfilesDir();
+		const tuckrDir = resolveTuckrDir();
 
-		const reloadScript = await findExecutable("tuckr:reload");
-		const fallbackScript =
-			`${dotfilesDir}/Configs/scripts/.local/bin/tuckr:reload`;
+		// Verify tuckr dotfiles location exists
+		try {
+			await Deno.stat(tuckrDir);
+		} catch {
+			printError(`Tuckr dotfiles location not found: ${tuckrDir}`);
+			printWarning("Run setup-tuckr-symlink.sh first.");
+			Deno.exit(1);
+		}
 
-		const script = reloadScript ?? fallbackScript;
-		const args: string[] = [];
+		// Check that tuckr is available
+		if (!(await commandExists("tuckr"))) {
+			printError("tuckr is not installed or not on PATH");
+			Deno.exit(1);
+		}
 
-		if (opts.group) args.push("--group", opts.group);
-		if (opts.force) args.push("--force");
-		if (opts.adopt) args.push("--adopt");
+		// Discover and filter groups
+		const allGroups = await discoverGroups(dotfilesDir);
+		if (allGroups.length === 0) {
+			printWarning("No configuration groups found in Configs directory");
+			return;
+		}
 
-		printHeader("Reloading dotfiles configuration");
-		const { code, success } = await runCommand([script, ...args], {
-			cwd: dotfilesDir,
+		const platformGroups = allGroups.filter((group) => {
+			if (isPlatformGroup(group)) {
+				return matchesPlatform(group);
+			}
+			return true;
 		});
 
-		if (!success) {
-			printError(`Reload failed with exit code ${code}`);
-			Deno.exit(code);
+		// Filter to a single group if --group was specified
+		const targetGroups = opts.group
+			? platformGroups.includes(opts.group) ? [opts.group] : (() => {
+				printError(`Unknown configuration group: ${opts.group}`);
+				console.log(
+					`Available groups: ${platformGroups.join(", ")}`,
+				);
+				Deno.exit(1);
+			})()
+			: platformGroups;
+
+		if (targetGroups.length === 0) {
+			printWarning("No matching groups found for current platform");
+			return;
 		}
+
+		const ordered = orderGroups(targetGroups);
+
+		// Show status first
+		printHeader("Tuckr Config Reload");
+		console.log("");
+		printInfo(`Location: ${tuckrDir}`);
+		printInfo(`Groups: ${ordered.join(", ")}`);
+		console.log("");
+
+		// Show current status
+		printInfo("Current tuckr status:");
+		await runCommand(["tuckr", "status"], { cwd: dotfilesDir });
+		console.log("");
+
+		// Build tuckr args
+		const tuckrArgs: string[] = [];
+		if (opts.dryRun) tuckrArgs.push("--dry-run");
+		if (opts.force) {
+			tuckrArgs.push("--force");
+			tuckrArgs.push("--assume-yes");
+		}
+		if (opts.adopt) tuckrArgs.push("--adopt");
+
+		// Deploy each group with the appropriate tuckr subcommand
+		for (const group of ordered) {
+			const subcommand = isHookGroup(group) ? "set" : "add";
+			const fullArgs = ["tuckr", subcommand, ...tuckrArgs, group];
+
+			if (opts.dryRun) {
+				printInfo(
+					`[dry-run] ${subcommand} ${tuckrArgs.join(" ")} ${group}`,
+				);
+			} else {
+				const label = isHookGroup(group) ? "with hooks" : "symlinks only";
+				printInfo(`Reloading group: ${group} — ${label}...`);
+
+				const { code, success } = await runCommand(fullArgs, {
+					cwd: dotfilesDir,
+				});
+
+				if (!success) {
+					printWarning(`Failed to reload group: ${group} (exit ${code})`);
+				} else {
+					printSuccess(`Group reloaded: ${group}`);
+				}
+			}
+		}
+
+		console.log("");
+		printSuccess("Tuckr reload complete!");
 	});


### PR DESCRIPTION
## Summary

Replaces the shell-out to the nushell `tuckr:reload` script with a native TypeScript implementation. The `dotfiles reload` command now handles all the logic that was previously in the 129-line nushell script:

### What changed

**Before:** `dotfiles reload` delegated to `tuckr:reload` (a nushell script) which:
- Detected the tuckr location (platform-specific)
- Discovered groups, filtered by platform, ordered them
- Called `tuckr add` or `tuckr set` for each group

**After:** `dotfiles reload` does all that natively in TypeScript using the same logic:
1. Discovers groups from `Configs/` directory (already had `discoverGroups()`)
2. Filters platform-specific groups based on `detectPlatform()`
3. Orders groups: **nix first**, regular alphabetically, **late groups last** (nushell, helix, claude)
4. Shows current `tuckr status` before reloading
5. Deploys each group with the correct subcommand:
   - Hook groups (nix, nushell, claude) → `tuckr set`
   - Regular groups → `tuckr add`
6. Supports `--force`, `--adopt`, `--dry-run`, and `--group <name>`

### Why this is better

- **Type-safe:** Group metadata, ordering, and platform logic are all type-checked
- **Discoverable:** Flags and help are self-documenting via cliffy
- **No nushell dependency** for reload (tuckr is still required)
- **Consistent output:** Same print helpers as other dotfiles subcommands
- **Testable:** Pure TypeScript, easy to unit test in Phase 3

### What's preserved

- The nushell script (`tuckr:reload`) is **not removed** — it stays for backward compatibility and will be deprecated in Phase 3
- `--force` and `--adopt` flags pass through to tuckr exactly as before
- `--dry-run` is new (the nushell script had it, we didn't expose it before)

## Test plan
- [x] `deno task check:all` passes (type check, oxlint, deno lint)
- [x] `dprint check` passes
- [x] `deno task compile:dev` produces working binary
- [x] `dotfiles reload --help` shows all flags
- [x] `dotfiles reload --group nix` works (delegates to tuckr)
