### PR TITLE
fix(ironclaw): add DOCKER_HOST for podman sandbox compatibility

### DIFF
--- a/Configs/ironclaw/.ironclaw/.env.base
+++ b/Configs/ironclaw/.ironclaw/.env.base
@@ -23,6 +23,8 @@ SELF_REPAIR_MAX_ATTEMPTS=3
 
 SANDBOX_ENABLED=true
 SANDBOX_POLICY=readonly
+# Podman Docker compatibility: set DOCKER_HOST so sandbox finds the podman socket.
+DOCKER_HOST=unix:///tmp/podman/podman-machine-default-api.sock
 
 # Web Gateway (browser UI) on the tailnet-only service port.
 GATEWAY_HOST=0.0.0.0


### PR DESCRIPTION
Ironclaw uses `SANDBOX_ENABLED=true` which requires Docker. On Mac Minis running podman instead of Docker, the sandbox can't find the Docker socket.

Add `DOCKER_HOST=unix:///tmp/podman/podman-machine-default-api.sock` to the Ironclaw env config so the sandbox connects to podman.