### PR TITLE
fix(tailscale): enable client routing defaults

### DIFF
--- a/Configs/nix/.config/nix/darwin.nix
+++ b/Configs/nix/.config/nix/darwin.nix
@@ -172,10 +172,10 @@
       ];
   };
 
-  # Enable Tailscale background service (launchd daemon on macOS, systemd on Linux)
+  # Enable the Tailscale background service automatically via launchd.
   services.tailscale.enable = true;
-  # Use Tailscale as exit node / subnet router (optional)
-  # services.tailscale.useRoutingFeatures = "both";
+  # Enable client-side routing support for tailnet IPs, MagicDNS, and accepted routes.
+  services.tailscale.useRoutingFeatures = "client";
 
   # Auto-start the podman VM on login for lite desktop Macs.
   # `podman machine start` is idempotent — exits cleanly if already running.

--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -160,7 +160,6 @@ in
 
       # Custom packages from ifiokjr/nixpkgs
       extra.cargo-interactive-update
-      extra.ccase
       extra.deno
       extra.ironclaw
       extra.monochange
@@ -199,7 +198,11 @@ in
       extra.godot
     ]
     ++ lib.optionals pkgs.stdenv.isDarwin (
-      lib.optionals (!lite) [
+      [
+        # macOS-only custom packages from ifiokjr/nixpkgs.
+        extra.ccase
+      ]
+      ++ lib.optionals (!lite) [
         # macOS-only packages (heavy, skipped in lite mode)
         powershell
       ]

--- a/docs/agents/ironclaw-setup.md
+++ b/docs/agents/ironclaw-setup.md
@@ -558,3 +558,10 @@ tailscale ping mini01
 # Check SSH connectivity
 ssh mini01 "echo connected"
 ```
+
+If `tailscale ping` works but browser/curl access to tailnet IPs or MagicDNS names times out, check for another VPN intercepting the `100.64.0.0/10` Tailscale range. NordVPN can block Tailscale routes and MagicDNS; pause or disconnect NordVPN, then retry:
+
+```bash
+curl --max-time 8 http://mini02.tailbfc6bf.ts.net:43210/api/health
+curl --max-time 8 http://100.97.208.114:43210/api/health
+```


### PR DESCRIPTION
## Summary
- enable Tailscale client routing features in Nix config
- document NordVPN as a possible blocker for Tailscale routes and MagicDNS

## Checks
- dprint check --config Configs/dprint/dprint.json
- nix flake check ./Configs/nix/.config/nix --impure --no-build