### PR TITLE
feat(cli): port doctor checks natively to TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
         run: |
           cd cli && deno task lint
 
+      - name: 🧪 test CLI (deno test)
+        run: |
+          cd cli && deno task test
+
       - name: 🏗️ compile CLI binary (deno compile)
         run: |
           cd cli && deno task compile:dev

--- a/cli/README.md
+++ b/cli/README.md
@@ -80,8 +80,10 @@ cd cli && deno task check:all                        # typecheck + lint
 
 ## Architecture
 
-- **Phase 1 (current):** All commands shell out to existing bash/nushell scripts
-- **Phase 2 (future):** Core commands reimplemented natively in TypeScript
+- **Phase 1:** CLI wrapper around existing bash/nushell scripts
+- **Phase 2 (current):** Port low-risk command logic natively when it improves readability and testability
 - **Phase 3 (future):** Interactive mode, TUI dashboard, completions
+
+`dotfiles setup` intentionally remains a thin wrapper around the existing setup script. Setup is a system-level bootstrapper that installs Nix, creates symlinks, and applies host configuration, so keeping the battle-tested shell script avoids bloating the CLI with risky duplicate orchestration.
 
 See `docs/proposals/dotfiles-cli.md` for the full proposal and migration plan.

--- a/cli/commands/doctor.ts
+++ b/cli/commands/doctor.ts
@@ -1,24 +1,375 @@
 /**
- * `dotfiles doctor` — Preflight / health checks
+ * `dotfiles doctor` — Preflight health checks.
  *
- * Phase 1: Shells out to `./setup --doctor`.
+ * Runs the same checks as `setup --doctor`, but natively in TypeScript so
+ * users can inspect and evolve the logic through the CLI codebase.
  */
 
 import { Command } from "@cliffy/command";
-import { printError, resolveDotfilesDir, runCommand } from "../lib/config.ts";
+import { dirname, join } from "@std/path";
+import {
+	commandExists,
+	detectPlatform,
+	type Platform,
+	printError,
+	printHeader,
+	printInfo,
+	printSuccess,
+	printWarning,
+	resolveDotfilesDir,
+} from "../lib/config.ts";
+
+/** Minimum free disk space recommended for Nix builds. */
+const MIN_HOME_DISK_BYTES = 10 * 1024 * 1024 * 1024;
+
+/** Mutable diagnostic counters shared by individual checks. */
+interface DoctorState {
+	problems: number;
+	warnings: number;
+}
+
+/** Result from running a subprocess without showing its output. */
+interface QuietCommandResult {
+	stdout: string;
+	success: boolean;
+}
+
+/** Options needed by preflight checks that depend on paths/platform. */
+interface DoctorContext {
+	dotfilesDir: string;
+	homeDir: string;
+	platform: Platform;
+}
+
+/** Run a subprocess and capture stdout while hiding noisy command output. */
+async function runQuiet(
+	command: string,
+	args: string[] = [],
+): Promise<QuietCommandResult> {
+	try {
+		const { stdout, success } = await new Deno.Command(command, {
+			args,
+			stdout: "piped",
+			stderr: "null",
+		}).output();
+
+		return {
+			stdout: new TextDecoder().decode(stdout),
+			success,
+		};
+	} catch {
+		return { stdout: "", success: false };
+	}
+}
+
+/** Check that a command exists and report a blocking problem when missing. */
+async function requireCommand(
+	name: string,
+	missingMessage: string,
+	state: DoctorState,
+): Promise<boolean> {
+	if (await commandExists(name)) {
+		printSuccess(`${name} available`);
+
+		return true;
+	}
+
+	printError(missingMessage);
+	state.problems++;
+
+	return false;
+}
+
+/** Check Git availability with platform-specific fallback guidance. */
+async function checkGit(platform: Platform, state: DoctorState): Promise<void> {
+	if (await commandExists("git")) {
+		printSuccess("Git available");
+
+		return;
+	}
+
+	if (platform === "macos") {
+		printWarning(
+			"Git is not runnable yet; setup can fall back to Nix, but Command Line Tools may still be missing",
+		);
+		state.warnings++;
+
+		return;
+	}
+
+	printWarning(
+		"Git is not installed; setup can install it temporarily after Nix",
+	);
+	state.warnings++;
+}
+
+/** Check whether sudo exists and whether it can currently run non-interactively. */
+async function checkSudo(state: DoctorState): Promise<void> {
+	if (!await commandExists("sudo")) {
+		printWarning("sudo not found; some setup paths may not work");
+		state.warnings++;
+
+		return;
+	}
+
+	const result = await runQuiet("sudo", ["-n", "true"]);
+
+	if (result.success) {
+		printSuccess("sudo available without prompting");
+
+		return;
+	}
+
+	printInfo("sudo available (setup may prompt when applying system changes)");
+}
+
+/** Check whether Nix is already installed and responding. */
+async function checkNix(state: DoctorState): Promise<void> {
+	if (!await commandExists("nix")) {
+		printInfo(
+			"Nix not installed (setup can install it unless --skip-nix is used)",
+		);
+
+		return;
+	}
+
+	const result = await runQuiet("nix", ["--version"]);
+
+	if (result.success) {
+		printSuccess("Nix installed and responding");
+
+		return;
+	}
+
+	printWarning("nix command found but not responding");
+	state.warnings++;
+}
+
+/** Check macOS Command Line Tools, which are commonly needed before Git works. */
+async function checkXcodeCommandLineTools(
+	platform: Platform,
+	state: DoctorState,
+): Promise<void> {
+	if (platform !== "macos") {
+		return;
+	}
+
+	const result = await runQuiet("xcode-select", ["-p"]);
+
+	if (result.success) {
+		printSuccess("Xcode Command Line Tools installed");
+
+		return;
+	}
+
+	printWarning("Xcode Command Line Tools are not installed yet");
+	state.warnings++;
+}
+
+/** Return available bytes for a path using portable POSIX `df -Pk` output. */
+async function availableDiskBytes(path: string): Promise<number | null> {
+	const result = await runQuiet("df", ["-Pk", path]);
+
+	if (!result.success) {
+		return null;
+	}
+
+	const lines = result.stdout.trim().split("\n");
+
+	if (lines.length < 2) {
+		return null;
+	}
+
+	const availableKb = Number.parseInt(lines[1].split(/\s+/)[3], 10);
+
+	if (Number.isNaN(availableKb)) {
+		return null;
+	}
+
+	return availableKb * 1024;
+}
+
+/** Warn when the home filesystem is likely too small for larger Nix builds. */
+async function checkDiskSpace(
+	homeDir: string,
+	state: DoctorState,
+): Promise<void> {
+	const freeBytes = await availableDiskBytes(homeDir);
+
+	if (freeBytes === null) {
+		printInfo("Could not determine free disk space");
+
+		return;
+	}
+
+	if (freeBytes >= MIN_HOME_DISK_BYTES) {
+		printSuccess("Sufficient free disk space detected");
+
+		return;
+	}
+
+	const freeGiB = (freeBytes / (1024 * 1024 * 1024)).toFixed(1);
+
+	printWarning(
+		`Less than 10 GiB free in the home filesystem (${freeGiB} GiB); large Nix builds may fail`,
+	);
+	state.warnings++;
+}
+
+/** Warn when GitHub API/downloads may be rate-limited. */
+function checkGitHubToken(state: DoctorState): void {
+	if (Deno.env.get("GITHUB_TOKEN")) {
+		printSuccess("GITHUB_TOKEN is set");
+
+		return;
+	}
+
+	printWarning(
+		"GITHUB_TOKEN is not set; GitHub-backed fetches may be rate limited",
+	);
+	state.warnings++;
+}
+
+/** Confirm setup can create the dotfiles and tuckr symlink parent directories. */
+async function checkWritableDirectories(
+	context: DoctorContext,
+	state: DoctorState,
+): Promise<void> {
+	const dotfilesParent = dirname(context.dotfilesDir);
+	const tuckrParent = dirname(
+		resolveTuckrPath(context.homeDir, context.platform),
+	);
+
+	await checkWritableDirectory(
+		dotfilesParent,
+		"Dotfiles parent directory",
+		state,
+	);
+
+	await checkWritableDirectory(
+		tuckrParent,
+		"Tuckr symlink parent directory",
+		state,
+	);
+}
+
+/** Check whether a directory can be created or written. */
+async function checkWritableDirectory(
+	path: string,
+	label: string,
+	state: DoctorState,
+): Promise<void> {
+	try {
+		await Deno.mkdir(path, { recursive: true });
+		printSuccess(`${label} is writable: ${path}`);
+	} catch {
+		printError(`Cannot write to ${label.toLowerCase()}: ${path}`);
+		state.problems++;
+	}
+}
+
+/** Resolve the platform-specific tuckr symlink path. */
+function resolveTuckrPath(homeDir: string, platform: Platform): string {
+	if (platform === "macos") {
+		return join(homeDir, "Library/Application Support/dotfiles");
+	}
+
+	return join(homeDir, ".config/dotfiles");
+}
+
+/** Check whether GitHub is reachable for bootstrap downloads and repository fetches. */
+async function checkGitHubReachability(state: DoctorState): Promise<void> {
+	const result = await runQuiet("curl", [
+		"--head",
+		"--silent",
+		"--fail",
+		"--location",
+		"--max-time",
+		"10",
+		"https://github.com",
+	]);
+
+	if (result.success) {
+		printSuccess("GitHub reachable");
+
+		return;
+	}
+
+	printWarning("GitHub could not be reached during the preflight check");
+	state.warnings++;
+}
+
+/** Print the final doctor result and exit non-zero for blocking issues. */
+function printDoctorSummary(state: DoctorState): void {
+	console.log("");
+
+	if (state.problems > 0) {
+		const issueText = pluralize("blocking issue", state.problems);
+		const warningText = pluralize("warning", state.warnings);
+
+		printError(
+			`Doctor found ${state.problems} ${issueText} and ${state.warnings} ${warningText}`,
+		);
+		Deno.exit(1);
+	}
+
+	if (state.warnings > 0) {
+		const warningText = pluralize("warning", state.warnings);
+
+		printWarning(
+			`Doctor found ${state.warnings} ${warningText}, but no blocking issues`,
+		);
+
+		return;
+	}
+
+	printSuccess("Doctor found no obvious blockers");
+}
+
+/** Return a singular/plural label for a count. */
+function pluralize(label: string, count: number): string {
+	return count === 1 ? label : `${label}s`;
+}
 
 export const doctorCommand = new Command()
 	.description("Run preflight checks without changing the machine")
 	.action(async () => {
 		const dotfilesDir = await resolveDotfilesDir();
-		const setupScript = `${dotfilesDir}/setup`;
+		const homeDir = Deno.env.get("HOME") ?? "~";
+		const platform = detectPlatform();
+		const state: DoctorState = { problems: 0, warnings: 0 };
+		const context: DoctorContext = { dotfilesDir, homeDir, platform };
 
-		const { code, success } = await runCommand([setupScript, "--doctor"], {
-			cwd: dotfilesDir,
-		});
+		printHeader("Dotfiles Doctor");
+		printSuccess(`Platform supported: ${platform}`);
 
-		if (!success) {
-			printError(`Doctor found issues (exit code ${code})`);
-			Deno.exit(code);
-		}
+		// === Required Tools ===
+		await requireCommand(
+			"curl",
+			"curl is required for bootstrap and is not installed",
+			state,
+		);
+
+		await checkGit(platform, state);
+
+		await checkSudo(state);
+
+		await checkNix(state);
+
+		// === Platform Checks ===
+		await checkXcodeCommandLineTools(platform, state);
+
+		// === System Capacity ===
+		await checkDiskSpace(homeDir, state);
+
+		// === Environment ===
+		checkGitHubToken(state);
+
+		// === Filesystem ===
+		await checkWritableDirectories(context, state);
+
+		// === Network ===
+		await checkGitHubReachability(state);
+
+		printDoctorSummary(state);
 	});

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -22,6 +22,7 @@
 	"imports": {
 		"@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
 		"@cliffy/prompt": "jsr:@cliffy/prompt@^1.0.0-rc.7",
+		"@std/assert": "jsr:@std/assert@^1.0.0",
 		"@std/fs": "jsr:@std/fs@^1.0.0",
 		"@std/path": "jsr:@std/path@^1.0.0",
 		"@std/toml": "jsr:@std/toml@^1.0.0",

--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -5,6 +5,7 @@
     "jsr:@cliffy/flags@1.1.0": "1.1.0",
     "jsr:@cliffy/internal@1.1.0": "1.1.0",
     "jsr:@cliffy/table@1.1.0": "1.1.0",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/fmt@^1.0.9": "1.0.10",
     "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
@@ -38,6 +39,12 @@
       "integrity": "6579680c9900628ccd0e05272e89ae483391d74a4f1dfe7c55c919e8a7320bcd",
       "dependencies": [
         "jsr:@std/fmt"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
       ]
     },
     "@std/fmt@1.0.10": {
@@ -189,6 +196,7 @@
     "dependencies": [
       "jsr:@cliffy/command@^1.0.0-rc.7",
       "jsr:@cliffy/prompt@^1.0.0-rc.7",
+      "jsr:@std/assert@1",
       "jsr:@std/fmt@1",
       "jsr:@std/fs@1",
       "jsr:@std/path@1",

--- a/cli/test/config_test.ts
+++ b/cli/test/config_test.ts
@@ -1,0 +1,21 @@
+import { assert, assertEquals } from "@std/assert";
+import {
+	detectPlatform,
+	discoverGroups,
+	resolveDotfilesDir,
+} from "../lib/config.ts";
+
+Deno.test("detectPlatform returns a supported platform label", () => {
+	const platform = detectPlatform();
+
+	assert(["macos", "linux", "windows", "bsd"].includes(platform));
+});
+
+Deno.test("discoverGroups finds repository config groups", async () => {
+	const dotfilesDir = await resolveDotfilesDir();
+	const groups = await discoverGroups(dotfilesDir);
+
+	assert(groups.length > 0);
+	assert(groups.includes("nix"));
+	assertEquals(groups, groups.toSorted());
+});


### PR DESCRIPTION
## Summary

Ports `dotfiles doctor` from shelling out to `./setup --doctor` to native TypeScript logic.

This follows the agreed migration approach:

- keep `dotfiles setup` as a shell-out to the battle-tested setup script
- only port low-risk command logic when it improves readability/testability
- do not port additional scripts in this PR

## Changes

- Reimplemented `dotfiles doctor` checks natively:
  - platform detection
  - curl/git/sudo/Nix checks
  - macOS Xcode Command Line Tools check
  - home filesystem free-space check
  - `GITHUB_TOKEN` warning
  - dotfiles/tuckr parent directory writability checks
  - GitHub reachability check
- Added Deno test coverage for shared CLI config helpers
- Added `deno task test` to cloud CI for the CLI
- Documented why `dotfiles setup` intentionally remains a shell-out
- Applied the CLI TypeScript style guide: extracted focused helpers, flat control flow, sectioned command action, dprint formatting

## Verification

- [x] `dprint check --config Configs/dprint/dprint.json`
- [x] `cd cli && deno task test`
- [x] `cd cli && deno task check:all`
- [x] `cd cli && deno task compile:dev`
- [x] `./dotfiles doctor`

