### PR TITLE
chore(scripts): deprecate direct rebuild command

### DIFF
--- a/Configs/codex/.config/codex/setup-codex.sh
+++ b/Configs/codex/.config/codex/setup-codex.sh
@@ -13,36 +13,36 @@ mkdir -p "$CODEX_DIR"
 
 # Check if secrets.env exists
 if [ ! -f "$CODEX_DIR/secrets.env" ]; then
-    echo ""
-    echo "⚠  secrets.env not found in $CODEX_DIR"
-    echo "   Create it with your API keys:"
-    echo ""
-    echo "   cat > $CODEX_DIR/secrets.env << 'EOF'"
-    echo "   XIAOMI_MIMO_API_KEY=tp-your-key-here"
-    echo "   OLLAMA_CLOUD_API_KEY=your-ollama-cloud-key"
-    echo "   EOF"
-    echo "   chmod 600 $CODEX_DIR/secrets.env"
-    echo ""
+	echo ""
+	echo "⚠  secrets.env not found in $CODEX_DIR"
+	echo "   Create it with your API keys:"
+	echo ""
+	echo "   cat > $CODEX_DIR/secrets.env << 'EOF'"
+	echo "   XIAOMI_MIMO_API_KEY=tp-your-key-here"
+	echo "   OLLAMA_CLOUD_API_KEY=your-ollama-cloud-key"
+	echo "   EOF"
+	echo "   chmod 600 $CODEX_DIR/secrets.env"
+	echo ""
 else
-    echo "✓ secrets.env exists"
+	echo "✓ secrets.env exists"
 fi
 
 # Add providers to config.toml if not already present
 if [ -f "$CONFIG" ]; then
-    if ! grep -q "\[model_providers.xiaomi\]" "$CONFIG"; then
-        echo "Adding custom providers to config.toml..."
-        if [ -f "$DOTFILES_CODEX_DIR/providers.toml" ]; then
-            echo "" >> "$CONFIG"
-            cat "$DOTFILES_CODEX_DIR/providers.toml" >> "$CONFIG"
-            echo "✓ Added custom providers"
-        else
-            echo "⚠ providers.toml not found in dotfiles"
-        fi
-    else
-        echo "✓ Custom providers already configured"
-    fi
+	if ! grep -q "\[model_providers.xiaomi\]" "$CONFIG"; then
+		echo "Adding custom providers to config.toml..."
+		if [ -f "$DOTFILES_CODEX_DIR/providers.toml" ]; then
+			echo "" >>"$CONFIG"
+			cat "$DOTFILES_CODEX_DIR/providers.toml" >>"$CONFIG"
+			echo "✓ Added custom providers"
+		else
+			echo "⚠ providers.toml not found in dotfiles"
+		fi
+	else
+		echo "✓ Custom providers already configured"
+	fi
 else
-    echo "⚠ config.toml not found — run 'codex' once to create it, then re-run this script"
+	echo "⚠ config.toml not found — run 'codex' once to create it, then re-run this script"
 fi
 
 echo ""

--- a/Configs/dprint/dprint.json
+++ b/Configs/dprint/dprint.json
@@ -62,6 +62,7 @@
 	"yaml": {},
 	"excludes": [
 		"**/pnpm-lock.yaml",
+		"**/.serena/**",
 		"**/dist",
 		"**/.devenv/**",
 		"**/fixtures",

--- a/Configs/nushell/.config/nushell/config.nu
+++ b/Configs/nushell/.config/nushell/config.nu
@@ -100,10 +100,7 @@ def --env pnpm_auto_activate [] {
     }
     if ($env.PATH | any {|p| $p == $node_bin }) == false { $env.PATH = ($env.PATH | prepend $node_bin) }
 }
-$env.config.hooks.env_change.PWD = (
-    ($env.config.hooks.env_change | get -o PWD | default [])
-    | append {|before, after| pnpm_auto_activate }
-)
+$env.config.hooks.env_change.PWD = (($env.config.hooks.env_change | get -o PWD | default []) | append {|before, after| pnpm_auto_activate })
 pnpm_auto_activate
 # Secrets
 use modules/secrets.nu [ssr, ssload]

--- a/Configs/nushell/.config/nushell/config.nu
+++ b/Configs/nushell/.config/nushell/config.nu
@@ -28,21 +28,21 @@ $env.config = {
                 # Capture stdout/stderr so direnv/devenv build errors don't corrupt prompt rendering.
                 # (e.g. "↑↓ navigatedirenv: failed to build the devenv environment")
                 let result = (^direnv export json | complete)
-                if ($result.exit_code != 0) {
+                if $result.exit_code != 0 {
                     if ($env | get -o DOTFILES_DEBUG | is-not-empty) {
-                        let err = ($result.stderr | str trim)
+                        let err = $result.stderr | str trim
                         if ($err | is-not-empty) { print $"(ansi yellow)direnv skipped:(ansi reset) ($err)" }
                     }
                     return
                 }
-                let stdout = ($result.stdout | str trim)
+                let stdout = $result.stdout | str trim
                 if ($stdout | is-empty) { return }
                 let direnv_out = (try {
                     $stdout | from json
                 } catch { {} })
                 if ($direnv_out | is-empty) { return }
                 let env_to_load = if ($direnv_out | get -o PATH | is-not-empty) {
-                    let path_as_list = ($direnv_out | get PATH | split row (char esep))
+                    let path_as_list = $direnv_out | get PATH | split row (char esep)
                     $direnv_out | merge { PATH: $path_as_list }
                 } else { $direnv_out }
                 $env_to_load | load-env
@@ -53,8 +53,8 @@ $env.config = {
                 {||
                     # Directory stack — push current directory, deduplicate, cap at 10.
                     # Mirrors zsh auto_pushd behaviour used by oh-my-zsh's `d` command.
-                    let dir = ($env.PWD | path expand)
-                    let stack = ($env | get -o DIRSTACK | default [])
+                    let dir = $env.PWD | path expand
+                    let stack = $env | get -o DIRSTACK | default []
                     $env.DIRSTACK = ([$dir] | append ($stack | where { $in != $dir }) | first 10)
                 }
             ]
@@ -66,7 +66,7 @@ $env.config = {
 source ~/.cache/devenv/hook.nu
 # Auto-activate Node.js from pnpm-workspace.yaml useNodeVersion (pnpm-standalone)
 def --env pnpm_auto_activate [] {
-    let debug = ($env | get -o DOTFILES_DEBUG | is-not-empty)
+    let debug = $env | get -o DOTFILES_DEBUG | is-not-empty
     if (which pnpm-activate-env | is-empty) {
         if $debug { print "(ansi yellow)pnpm_auto_activate skipped: pnpm-activate-env not found(ansi reset)" }
         return
@@ -76,12 +76,12 @@ def --env pnpm_auto_activate [] {
         if $debug { print "(ansi yellow)pnpm_auto_activate skipped: pnpm-activate-env failed(ansi reset)" }
         return
     }
-    let output_lines = ($res.stdout | str trim | lines)
+    let output_lines = $res.stdout | str trim | lines
     if ($output_lines | is-empty) {
         if $debug { print "(ansi yellow)pnpm_auto_activate skipped: pnpm-activate-env returned no output lines(ansi reset)" }
         return
     }
-    let first = ($output_lines | first)
+    let first = $output_lines | first
     if $first == "" {
         if $debug { print "(ansi yellow)pnpm_auto_activate skipped: pnpm-activate-env returned no output lines(ansi reset)" }
         return
@@ -93,14 +93,17 @@ def --env pnpm_auto_activate [] {
         if $debug { print "(ansi yellow)pnpm_auto_activate skipped: pnpm-activate-env output did not include node bin(ansi reset)" }
         return
     }
-    let node_bin = ($parsed | get -o 0.bin)
+    let node_bin = $parsed | get -o 0.bin
     if $node_bin == "" {
         if $debug { print "(ansi yellow)pnpm_auto_activate skipped: parsed node bin was empty(ansi reset)" }
         return
     }
-    if ($env.PATH | any { |p| $p == $node_bin }) == false { $env.PATH = ($env.PATH | prepend $node_bin) }
+    if ($env.PATH | any {|p| $p == $node_bin }) == false { $env.PATH = ($env.PATH | prepend $node_bin) }
 }
-$env.config.hooks.env_change.PWD = (($env.config.hooks.env_change | get -o PWD | default []) | append { |before, after| pnpm_auto_activate })
+$env.config.hooks.env_change.PWD = (
+    ($env.config.hooks.env_change | get -o PWD | default [])
+    | append {|before, after| pnpm_auto_activate }
+)
 pnpm_auto_activate
 # Secrets
 use modules/secrets.nu [ssr, ssload]
@@ -172,13 +175,13 @@ def git_main_branch [] {
     let branches = (
         ^git branch --list main master | lines | each { str trim } | where { $in != "" }
     )
-    if ("main" in $branches) { "main" } else if ("master" in $branches) { "master" } else { "main" }
+    if "main" in $branches { "main" } else if "master" in $branches { "master" } else { "main" }
 }
 def git_develop_branch [] {
     let branches = (
         ^git branch --list dev develop development | lines | each { str trim } | where { $in != "" }
     )
-    if ("develop" in $branches) { "develop" } else if ("dev" in $branches) { "dev" } else if ("development" in $branches) { "development" } else { "develop" }
+    if "develop" in $branches { "develop" } else if "dev" in $branches { "dev" } else if "development" in $branches { "development" } else { "develop" }
 }
 def git_current_branch [] {
     ^git branch --show-current | str trim
@@ -439,7 +442,7 @@ def gsqa [message: string] {
 # Open in Cursor
 def c [...paths: string] {
     if ($paths | is-empty) { ^open -a "Cursor" . } else {
-        $paths | each { |p| ^open -a "Cursor" $p }
+        $paths | each {|p| ^open -a "Cursor" $p }
     }
 }
 # Directory history (like oh-my-zsh 'd' command)
@@ -450,12 +453,12 @@ def --env d [index?: int] {
     let dirs = ($env | get -o DIRSTACK | default [
         $env.PWD
     ])
-    if ($index != null) {
+    if $index != null {
         if $index >= 0 and $index < ($dirs | length) { cd ($dirs | get $index) } else { print $"(ansi red)Invalid index:(ansi reset) ($index) \(0-($dirs | length | $in - 1)\)" }
         return
     }
     $dirs | enumerate | each { |r|
-        let display = ($r.item | str replace $env.HOME "~")
+        let display = $r.item | str replace $env.HOME "~"
         print $"(ansi cyan)($r.index)(ansi reset)\t($display)"
     }
     null

--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -8,7 +8,7 @@ $env._SHELL_START = (date now)
 # nix-darwin's set-environment has not run), detect and set them manually.
 if not ($env | get -o NIX_PROFILES | is-not-empty) {
     # Replicate nix-darwin's set-environment script
-    let user = ($env | get -o USER | default (whoami))
+    let user = $env | get -o USER | default (whoami)
     # Nix profiles (matches nix-darwin set-environment)
     $env.NIX_PROFILES = $"/nix/var/nix/profiles/default /run/current-system/sw /etc/profiles/per-user/($user) ($env.HOME)/.nix-profile"
     $env.NIX_USER_PROFILE_DIR = $"/nix/var/nix/profiles/per-user/($user)"
@@ -59,7 +59,7 @@ $env.DENO_INSTALL = $"($env.HOME)/.deno"
 $env.ANDROID_HOME = $"($env.HOME)/Library/Android/sdk"
 let ndk_base = $"($env.ANDROID_HOME)/ndk"
 $env.NDK_HOME = if ($ndk_base | path exists) {
-    let ndks = (ls $ndk_base | where type == dir | sort-by name)
+    let ndks = ls $ndk_base | where type == dir | sort-by name
     if ($ndks | is-not-empty) {
         $ndks | last | get name
     } else { $"($ndk_base)/29.0.13599879" }
@@ -76,7 +76,10 @@ $env.PNPM_HOME = $"($env.HOME)/Library/pnpm"
 # connect to the podman VM. The `docker` CLI alias (podman) works without this.
 # Falls back to the standard macOS Podman socket if dynamic detection fails.
 if ($nu.os-info.name == "macos") and (which podman | is-not-empty) {
-    let _docker_sock = (do -i { podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanSocket.Path}}' } | str trim)
+    let _docker_sock = (
+        do -i { podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanSocket.Path}}' }
+        | str trim
+    )
     if ($_docker_sock | path exists) {
         $env.DOCKER_HOST = "unix://" + $_docker_sock
     } else if ("/tmp/podman/podman-machine-default-api.sock" | path exists) {
@@ -123,6 +126,7 @@ let path_prepend = [
     $"($env.HOME)/fvm/default/bin"
     $"($env.DENO_INSTALL)/bin"
 ]
+
 let path_append = [
     $"($env.ANDROID_HOME)/cmdline-tools/latest/bin"
     $"($env.ANDROID_HOME)/platform-tools"
@@ -142,9 +146,7 @@ $env.OPENCODE_TRUSTED_DIRECTORIES = "/Users/ifiokjr/Developer,/tmp"
 # ---------------------------------------------------------------------------
 # Directory stack (like zsh auto_pushd)
 # ---------------------------------------------------------------------------
-$env.DIRSTACK = [
-    $env.PWD
-]
+$env.DIRSTACK = [$env.PWD]
 # ---------------------------------------------------------------------------
 # Devenv hook cache (runs in env.nu so the file exists before config.nu parses)
 # ---------------------------------------------------------------------------
@@ -152,12 +154,13 @@ $env.DIRSTACK = [
 # Any runtime code in config.nu would execute too late. Since env.nu is
 # fully parsed and executed before config.nu, we create/refresh the cache here.
 mkdir ~/.cache/devenv
-let devenv_bin = (which devenv | get path.0 | default '')
+let devenv_bin = which devenv | get path.0 | default ''
+
 let needs_regen = if ($devenv_bin | is-empty) { false } else {
-    let cache_exists = ($"($env.HOME)/.cache/devenv/hook.nu" | path exists)
+    let cache_exists = $"($env.HOME)/.cache/devenv/hook.nu" | path exists
     if not $cache_exists { true } else {
-        let cache_mtime = (ls -l $"($env.HOME)/.cache/devenv/hook.nu" | get modified.0)
-        let bin_mtime = (ls -l $devenv_bin | get modified.0)
+        let cache_mtime = ls -l $"($env.HOME)/.cache/devenv/hook.nu" | get modified.0
+        let bin_mtime = ls -l $devenv_bin | get modified.0
         ($cache_mtime < $bin_mtime)
     }
 }
@@ -171,8 +174,8 @@ if not ("~/.cache/devenv/hook.nu" | path expand | path exists) {
 # pnpm
 $env.PNPM_HOME = "/Users/ifiokjr/Library/pnpm"
 $env.PATH = ($env.PATH | split row (char esep) | prepend ($env.PNPM_HOME | path join "bin"))
-# pnpm end
 
+# pnpm end
 
 # ---------------------------------------------------------------------------
 # Codex API Keys
@@ -181,7 +184,13 @@ $env.PATH = ($env.PATH | split row (char esep) | prepend ($env.PNPM_HOME | path 
 # Primary source: 1Password via secretspec (use `ssr codex ...`)
 # Fallback: ~/.codex/secrets.env for offline use
 if ("~/.codex/secrets.env" | path exists) {
-    let secrets = (open ~/.codex/secrets.env --raw | lines | where {|l| not ($l | str starts-with '#') and ($l | str contains '=')} | parse '{key}={value}' | transpose -r)
+    let secrets = (
+        open ~/.codex/secrets.env --raw
+        | lines
+        | where {|l| not ($l | str starts-with '#') and ($l | str contains '=')}
+        | parse '{key}={value}'
+        | transpose -r
+    )
     if ($secrets | get -o XIAOMI_MIMO_API_KEY | is-not-empty) {
         $env.XIAOMI_MIMO_API_KEY = ($secrets | get XIAOMI_MIMO_API_KEY)
     }

--- a/Configs/nushell/.config/nushell/env.nu
+++ b/Configs/nushell/.config/nushell/env.nu
@@ -76,10 +76,7 @@ $env.PNPM_HOME = $"($env.HOME)/Library/pnpm"
 # connect to the podman VM. The `docker` CLI alias (podman) works without this.
 # Falls back to the standard macOS Podman socket if dynamic detection fails.
 if ($nu.os-info.name == "macos") and (which podman | is-not-empty) {
-    let _docker_sock = (
-        do -i { podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanSocket.Path}}' }
-        | str trim
-    )
+    let _docker_sock = (do -i { podman machine inspect podman-machine-default --format '{{.ConnectionInfo.PodmanSocket.Path}}' } | str trim)
     if ($_docker_sock | path exists) {
         $env.DOCKER_HOST = "unix://" + $_docker_sock
     } else if ("/tmp/podman/podman-machine-default-api.sock" | path exists) {
@@ -126,7 +123,6 @@ let path_prepend = [
     $"($env.HOME)/fvm/default/bin"
     $"($env.DENO_INSTALL)/bin"
 ]
-
 let path_append = [
     $"($env.ANDROID_HOME)/cmdline-tools/latest/bin"
     $"($env.ANDROID_HOME)/platform-tools"
@@ -146,7 +142,9 @@ $env.OPENCODE_TRUSTED_DIRECTORIES = "/Users/ifiokjr/Developer,/tmp"
 # ---------------------------------------------------------------------------
 # Directory stack (like zsh auto_pushd)
 # ---------------------------------------------------------------------------
-$env.DIRSTACK = [$env.PWD]
+$env.DIRSTACK = [
+    $env.PWD
+]
 # ---------------------------------------------------------------------------
 # Devenv hook cache (runs in env.nu so the file exists before config.nu parses)
 # ---------------------------------------------------------------------------
@@ -155,7 +153,6 @@ $env.DIRSTACK = [$env.PWD]
 # fully parsed and executed before config.nu, we create/refresh the cache here.
 mkdir ~/.cache/devenv
 let devenv_bin = which devenv | get path.0 | default ''
-
 let needs_regen = if ($devenv_bin | is-empty) { false } else {
     let cache_exists = $"($env.HOME)/.cache/devenv/hook.nu" | path exists
     if not $cache_exists { true } else {
@@ -174,9 +171,7 @@ if not ("~/.cache/devenv/hook.nu" | path expand | path exists) {
 # pnpm
 $env.PNPM_HOME = "/Users/ifiokjr/Library/pnpm"
 $env.PATH = ($env.PATH | split row (char esep) | prepend ($env.PNPM_HOME | path join "bin"))
-
 # pnpm end
-
 # ---------------------------------------------------------------------------
 # Codex API Keys
 # ---------------------------------------------------------------------------
@@ -184,13 +179,7 @@ $env.PATH = ($env.PATH | split row (char esep) | prepend ($env.PNPM_HOME | path 
 # Primary source: 1Password via secretspec (use `ssr codex ...`)
 # Fallback: ~/.codex/secrets.env for offline use
 if ("~/.codex/secrets.env" | path exists) {
-    let secrets = (
-        open ~/.codex/secrets.env --raw
-        | lines
-        | where {|l| not ($l | str starts-with '#') and ($l | str contains '=')}
-        | parse '{key}={value}'
-        | transpose -r
-    )
+    let secrets = (open ~/.codex/secrets.env --raw | lines | where {|l| not ($l | str starts-with '#') and ($l | str contains '=')} | parse '{key}={value}' | transpose -r)
     if ($secrets | get -o XIAOMI_MIMO_API_KEY | is-not-empty) {
         $env.XIAOMI_MIMO_API_KEY = ($secrets | get XIAOMI_MIMO_API_KEY)
     }

--- a/Configs/nushell/.config/nushell/modules/secrets.nu
+++ b/Configs/nushell/.config/nushell/modules/secrets.nu
@@ -16,29 +16,25 @@ export alias ssr = secretspec run -f $"($env.HOME)/secretspec.toml" --
 export def --env ssload [] {
     let secretspec_file = $"($env.HOME)/secretspec.toml"
     if not ($secretspec_file | path exists) {
-        error make {
-            msg: $"ssload: missing ($secretspec_file)"
-        }
+        error make {msg: $"ssload: missing ($secretspec_file)"}
     }
     let keys = (
-        open $secretspec_file | get profiles.default | columns | where { |key| $key != "defaults" }
+        open $secretspec_file | get profiles.default | columns | where {|key| $key != "defaults" }
     )
     if ($keys | is-empty) {
-        error make {
-            msg: $"ssload: no secrets found in ($secretspec_file)"
-        }
+        error make {msg: $"ssload: no secrets found in ($secretspec_file)"}
     }
     let env_vars = (
         ^secretspec run -f $secretspec_file -- env | lines | each { |line|
-            let idx = ($line | str index-of "=")
+            let idx = $line | str index-of "="
             if $idx == -1 { return null }
 
-            let key = ($line | str substring 0..<$idx)
+            let key = $line | str substring 0..<$idx
             if $key not-in $keys { return null }
 
-            let value = ($line | str substring ($idx + 1)..)
+            let value = $line | str substring ($idx + 1)..
             { $key: $value }
-        } | where { |item| $item != null } | reduce --fold {} { |item, acc| $acc | merge $item }
+        } | where {|item| $item != null } | reduce --fold {} {|item, acc| $acc | merge $item }
     )
     if ($env_vars | is-not-empty) {
         $env_vars | load-env

--- a/Configs/nushell/.config/nushell/modules/secrets.nu
+++ b/Configs/nushell/.config/nushell/modules/secrets.nu
@@ -16,13 +16,17 @@ export alias ssr = secretspec run -f $"($env.HOME)/secretspec.toml" --
 export def --env ssload [] {
     let secretspec_file = $"($env.HOME)/secretspec.toml"
     if not ($secretspec_file | path exists) {
-        error make {msg: $"ssload: missing ($secretspec_file)"}
+        error make {
+            msg: $"ssload: missing ($secretspec_file)"
+        }
     }
     let keys = (
         open $secretspec_file | get profiles.default | columns | where {|key| $key != "defaults" }
     )
     if ($keys | is-empty) {
-        error make {msg: $"ssload: no secrets found in ($secretspec_file)"}
+        error make {
+            msg: $"ssload: no secrets found in ($secretspec_file)"
+        }
     }
     let env_vars = (
         ^secretspec run -f $secretspec_file -- env | lines | each { |line|

--- a/Configs/scripts/.local/bin/nu_modules/nix_config.nu
+++ b/Configs/scripts/.local/bin/nu_modules/nix_config.nu
@@ -35,7 +35,9 @@ export def machine-config-path [] { $"(config-dir)/machine.nix" }
 export def set-desktop-mode [value: bool, --path(-p): string] {
     let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {msg: $"machine.nix not found at: ($target_path)"}
+        error make {
+            msg: $"machine.nix not found at: ($target_path)"
+        }
     }
     let content = (open $target_path --raw)
     let desktop_value = (if $value { "true" } else { "false" })
@@ -52,7 +54,9 @@ export def set-desktop-mode [value: bool, --path(-p): string] {
 export def set-lite-mode [value: bool, --path(-p): string] {
     let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {msg: $"machine.nix not found at: ($target_path)"}
+        error make {
+            msg: $"machine.nix not found at: ($target_path)"
+        }
     }
     let content = (open $target_path --raw)
     let lite_value = (if $value { "true" } else { "false" })
@@ -72,7 +76,9 @@ export def set-lite-mode [value: bool, --path(-p): string] {
 export def set-always-on-mode [value: bool, --path(-p): string] {
     let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {msg: $"machine.nix not found at: ($target_path)"}
+        error make {
+            msg: $"machine.nix not found at: ($target_path)"
+        }
     }
     let content = (open $target_path --raw)
     let always_on_value = (if $value { "true" } else { "false" })
@@ -99,21 +105,20 @@ export def add-preset [preset: string, --path(-p): string] {
     let known = (known-presets)
     let preset_names = $known | columns
     if $preset not-in $preset_names {
-        error make {msg: $"Unknown preset '($preset)'. Available presets: ($preset_names | str join ', ')"}
+        error make {
+            msg: $"Unknown preset '($preset)'. Available presets: ($preset_names | str join ', ')"
+        }
     }
     let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {msg: $"machine.nix not found at: ($target_path)"}
+        error make {
+            msg: $"machine.nix not found at: ($target_path)"
+        }
     }
     let content = (open $target_path --raw)
     # Parse current presets list (if any)
     let current_entries = try {
-        let raw = (
-            $content
-            | parse --regex 'presets\s*=\s*\[([^\]]*)\]'
-            | get capture0.0
-            | str trim
-        )
+        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
         if ($raw | is-empty) { [] } else {
             $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
         }
@@ -137,7 +142,9 @@ export def remove-preset [preset: string, --path(-p): string] {
     let preset = $preset | str trim | str downcase
     let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {msg: $"machine.nix not found at: ($target_path)"}
+        error make {
+            msg: $"machine.nix not found at: ($target_path)"
+        }
     }
     let content = (open $target_path --raw)
     if not ($content | str contains 'presets =') {
@@ -145,12 +152,7 @@ export def remove-preset [preset: string, --path(-p): string] {
     }
     # Parse current entries and remove the target
     let current_entries = try {
-        let raw = (
-            $content
-            | parse --regex 'presets\s*=\s*\[([^\]]*)\]'
-            | get capture0.0
-            | str trim
-        )
+        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
         if ($raw | is-empty) { [] } else {
             $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
         }
@@ -171,7 +173,9 @@ export def remove-preset [preset: string, --path(-p): string] {
 export def parse-machine-config [] {
     let path = (machine-config-path)
     if not ($path | path exists) {
-        error make {msg: $"machine.nix not found at: ($path)"}
+        error make {
+            msg: $"machine.nix not found at: ($path)"
+        }
     }
     let content = (open $path --raw)
     # `parse --regex` returns a table; `.get capture0.0` grabs the first match
@@ -183,34 +187,19 @@ export def parse-machine-config [] {
     } catch { "" }
     # lite is optional — older machine.nix files may not have it
     let lite = try {
-        (
-        ($content | parse --regex 'lite\s*=\s*(true|false);' | get capture0.0) == "true"
-    )
+        (($content | parse --regex 'lite\s*=\s*(true|false);' | get capture0.0) == "true")
     } catch { false }
     # isDesktop is optional — older machine.nix files may not have it
     let isDesktop = try {
-        (
-        (
-            $content
-            | parse --regex 'isDesktop\s*=\s*(true|false);'
-            | get capture0.0
-        ) == "true"
-    )
+        (($content | parse --regex 'isDesktop\s*=\s*(true|false);' | get capture0.0) == "true")
     } catch { false }
     # alwaysOn is optional — older machine.nix files may not have it
     let alwaysOn = try {
-        (
-        ($content | parse --regex 'alwaysOn\s*=\s*(true|false);' | get capture0.0) == "true"
-    )
+        (($content | parse --regex 'alwaysOn\s*=\s*(true|false);' | get capture0.0) == "true")
     } catch { false }
     # presets is optional — a quoted list inside brackets
     let presets = try {
-        let raw = (
-            $content
-            | parse --regex 'presets\s*=\s*\[([^\]]*)\]'
-            | get capture0.0
-            | str trim
-        )
+        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
         if ($raw | is-empty) { [] } else {
             $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
         }

--- a/Configs/scripts/.local/bin/nu_modules/nix_config.nu
+++ b/Configs/scripts/.local/bin/nu_modules/nix_config.nu
@@ -33,11 +33,9 @@ export def machine-config-path [] { $"(config-dir)/machine.nix" }
 # Set the machine.nix desktop mode flag (inserts the field if missing).
 # When isDesktop=true AND lite=true on macOS, enables Docker via podman.
 export def set-desktop-mode [value: bool, --path(-p): string] {
-    let target_path = ($path | default (machine-config-path))
+    let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {
-            msg: $"machine.nix not found at: ($target_path)"
-        }
+        error make {msg: $"machine.nix not found at: ($target_path)"}
     }
     let content = (open $target_path --raw)
     let desktop_value = (if $value { "true" } else { "false" })
@@ -52,11 +50,9 @@ export def set-desktop-mode [value: bool, --path(-p): string] {
 }
 # Set the machine.nix lite mode flag (inserts the field if missing).
 export def set-lite-mode [value: bool, --path(-p): string] {
-    let target_path = ($path | default (machine-config-path))
+    let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {
-            msg: $"machine.nix not found at: ($target_path)"
-        }
+        error make {msg: $"machine.nix not found at: ($target_path)"}
     }
     let content = (open $target_path --raw)
     let lite_value = (if $value { "true" } else { "false" })
@@ -74,11 +70,9 @@ export def set-lite-mode [value: bool, --path(-p): string] {
 # activates with password lock after display sleep. Intended for always-plugged-in
 # desktops (e.g. Mac Mini) that must stay reachable at all times.
 export def set-always-on-mode [value: bool, --path(-p): string] {
-    let target_path = ($path | default (machine-config-path))
+    let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {
-            msg: $"machine.nix not found at: ($target_path)"
-        }
+        error make {msg: $"machine.nix not found at: ($target_path)"}
     }
     let content = (open $target_path --raw)
     let always_on_value = (if $value { "true" } else { "false" })
@@ -101,24 +95,25 @@ export def set-always-on-mode [value: bool, --path(-p): string] {
 export def known-presets [] { {ironclaw: "Ironclaw agent runtime — enables libSQL database and ironclaw service"} }
 # Add a preset to machine.nix (inserts the presets list if missing, appends if present).
 export def add-preset [preset: string, --path(-p): string] {
-    let preset = ($preset | str downcase)
+    let preset = $preset | str downcase
     let known = (known-presets)
-    let preset_names = ($known | columns)
+    let preset_names = $known | columns
     if $preset not-in $preset_names {
-        error make {
-            msg: $"Unknown preset '($preset)'. Available presets: ($preset_names | str join ', ')"
-        }
+        error make {msg: $"Unknown preset '($preset)'. Available presets: ($preset_names | str join ', ')"}
     }
-    let target_path = ($path | default (machine-config-path))
+    let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {
-            msg: $"machine.nix not found at: ($target_path)"
-        }
+        error make {msg: $"machine.nix not found at: ($target_path)"}
     }
     let content = (open $target_path --raw)
     # Parse current presets list (if any)
     let current_entries = try {
-        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
+        let raw = (
+            $content
+            | parse --regex 'presets\s*=\s*\[([^\]]*)\]'
+            | get capture0.0
+            | str trim
+        )
         if ($raw | is-empty) { [] } else {
             $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
         }
@@ -127,7 +122,7 @@ export def add-preset [preset: string, --path(-p): string] {
     if $preset in $current_entries {
         return
     }
-    let new_entries = ($current_entries | append $preset | each {|x| $'"($x)"'})
+    let new_entries = $current_entries | append $preset | each {|x| $'"($x)"'}
     let preset_line = $"  presets = [($new_entries | str join ' ')];"
     let updated = if ($content | str contains 'presets =') {
         $content | str replace --regex '(?m)^\s*presets\s*=\s*\[[^\]]*\];\s*$' $preset_line
@@ -139,12 +134,10 @@ export def add-preset [preset: string, --path(-p): string] {
 }
 # Remove a preset from machine.nix (removes from the list, cleans up empty list).
 export def remove-preset [preset: string, --path(-p): string] {
-    let preset = ($preset | str trim | str downcase)
-    let target_path = ($path | default (machine-config-path))
+    let preset = $preset | str trim | str downcase
+    let target_path = $path | default (machine-config-path)
     if not ($target_path | path exists) {
-        error make {
-            msg: $"machine.nix not found at: ($target_path)"
-        }
+        error make {msg: $"machine.nix not found at: ($target_path)"}
     }
     let content = (open $target_path --raw)
     if not ($content | str contains 'presets =') {
@@ -152,12 +145,17 @@ export def remove-preset [preset: string, --path(-p): string] {
     }
     # Parse current entries and remove the target
     let current_entries = try {
-        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
+        let raw = (
+            $content
+            | parse --regex 'presets\s*=\s*\[([^\]]*)\]'
+            | get capture0.0
+            | str trim
+        )
         if ($raw | is-empty) { [] } else {
             $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
         }
     } catch { [] }
-    let new_entries = ($current_entries | where {|x| $x != $preset} | each {|x| $'"($x)"'})
+    let new_entries = $current_entries | where {|x| $x != $preset} | each {|x| $'"($x)"'}
     let updated = if ($new_entries | length) > 0 {
         let preset_line = $"  presets = [($new_entries | str join ' ')];"
         $content | str replace --regex '(?m)^\s*presets\s*=\s*\[[^\]]*\];\s*$' $preset_line
@@ -173,27 +171,46 @@ export def remove-preset [preset: string, --path(-p): string] {
 export def parse-machine-config [] {
     let path = (machine-config-path)
     if not ($path | path exists) {
-        error make {
-            msg: $"machine.nix not found at: ($path)"
-        }
+        error make {msg: $"machine.nix not found at: ($path)"}
     }
     let content = (open $path --raw)
     # `parse --regex` returns a table; `.get capture0.0` grabs the first match
-    let username = ($content | parse --regex 'username = "([^"]+)"' | get capture0.0)
-    let system = ($content | parse --regex 'system = "([^"]+)"' | get capture0.0)
+    let username = $content | parse --regex 'username = "([^"]+)"' | get capture0.0
+    let system = $content | parse --regex 'system = "([^"]+)"' | get capture0.0
     # hostname is optional — older machine.nix files may not have it
     let hostname = try {
         $content | parse --regex 'hostname = "([^"]+)"' | get capture0.0
     } catch { "" }
     # lite is optional — older machine.nix files may not have it
-    let lite = try { (($content | parse --regex 'lite\s*=\s*(true|false);' | get capture0.0) == "true") } catch { false }
+    let lite = try {
+        (
+        ($content | parse --regex 'lite\s*=\s*(true|false);' | get capture0.0) == "true"
+    )
+    } catch { false }
     # isDesktop is optional — older machine.nix files may not have it
-    let isDesktop = try { (($content | parse --regex 'isDesktop\s*=\s*(true|false);' | get capture0.0) == "true") } catch { false }
+    let isDesktop = try {
+        (
+        (
+            $content
+            | parse --regex 'isDesktop\s*=\s*(true|false);'
+            | get capture0.0
+        ) == "true"
+    )
+    } catch { false }
     # alwaysOn is optional — older machine.nix files may not have it
-    let alwaysOn = try { (($content | parse --regex 'alwaysOn\s*=\s*(true|false);' | get capture0.0) == "true") } catch { false }
+    let alwaysOn = try {
+        (
+        ($content | parse --regex 'alwaysOn\s*=\s*(true|false);' | get capture0.0) == "true"
+    )
+    } catch { false }
     # presets is optional — a quoted list inside brackets
     let presets = try {
-        let raw = ($content | parse --regex 'presets\s*=\s*\[([^\]]*)\]' | get capture0.0 | str trim)
+        let raw = (
+            $content
+            | parse --regex 'presets\s*=\s*\[([^\]]*)\]'
+            | get capture0.0
+            | str trim
+        )
         if ($raw | is-empty) { [] } else {
             $raw | split row ' ' | where {|x| $x | is-not-empty} | each {|x| $x | str replace --all '"' '' | str trim }
         }

--- a/Configs/scripts/.local/bin/nu_modules/platform.nu
+++ b/Configs/scripts/.local/bin/nu_modules/platform.nu
@@ -13,9 +13,9 @@ export def arch [] {
     match $machine {
         "arm64" | "aarch64" => "aarch64"
         x86_64 => "x86_64"
-        _ => {
-            error make {msg: $"Unsupported architecture: ($machine)"}
-        }
+        _ => { error make {
+            msg: $"Unsupported architecture: ($machine)"
+        } }
     }
 }
 # Get nix system triple (e.g., "aarch64-darwin")

--- a/Configs/scripts/.local/bin/nu_modules/platform.nu
+++ b/Configs/scripts/.local/bin/nu_modules/platform.nu
@@ -12,10 +12,10 @@ export def arch [] {
     let machine = (uname).machine
     match $machine {
         "arm64" | "aarch64" => "aarch64"
-        "x86_64" => "x86_64"
-        _ => { error make {
-            msg: $"Unsupported architecture: ($machine)"
-        } }
+        x86_64 => "x86_64"
+        _ => {
+            error make {msg: $"Unsupported architecture: ($machine)"}
+        }
     }
 }
 # Get nix system triple (e.g., "aarch64-darwin")

--- a/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
+++ b/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
@@ -115,7 +115,10 @@ export def diff-package-lists [old: list<any>, new: list<any>] {
 # ─────────────────────────────────────────────────────────────────────────────
 # Print a package diff returned by diff-package-lists.
 export def print-package-diff [diff: record, title: string] {
-    let total = $diff.added | length) + ($diff.removed | length) + ($diff.changed | length
+    let added_count = $diff.added | length
+    let removed_count = $diff.removed | length
+    let changed_count = $diff.changed | length
+    let total = $added_count + $removed_count + $changed_count
     if $total == 0 { return }
     header $title
     for pkg in $diff.added { success $"  + ($pkg.name) ($pkg.new)" }

--- a/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
+++ b/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
@@ -24,7 +24,7 @@ export def diff-nix-closures [old_path: string, new_path: string] {
         return null
     }
     let result = (^nix store diff-closures $old_path $new_path | complete)
-    if ($result.exit_code != 0) {
+    if $result.exit_code != 0 {
         return null
     }
     $result.stdout | lines | where $it != ""
@@ -35,10 +35,17 @@ export def diff-nix-closures [old_path: string, new_path: string] {
 # Return a list of {name, version} records for managed pnpm global project packages.
 export def capture-pnpm-globals [] {
     if (which pnpm | is-empty) { return null }
-    let runtime_dir = ($env.XDG_DATA_HOME? | default ($env.HOME | path join ".local/share") | path join "pnpm-global")
+    let runtime_dir = (
+        $env.XDG_DATA_HOME?
+        | default ($env.HOME | path join ".local/share")
+        | path join "pnpm-global"
+    )
     if not ($runtime_dir | path join "package.json" | path exists) { return null }
-    let result = (^bash -lc 'cd "${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global" && pnpm list --json' | complete)
-    if ($result.exit_code != 0) { return null }
+    let result = (
+        ^bash -lc 'cd "${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global" && pnpm list --json'
+        | complete
+    )
+    if $result.exit_code != 0 { return null }
     let parsed = try {
         $result.stdout | from json
     } catch { return null }
@@ -57,7 +64,7 @@ export def capture-pnpm-globals [] {
     if ($deps_type | str contains "nothing") or (not ($deps_type | str starts-with "record")) {
         return null
     }
-    $deps | items { |name, info| { name: $name, version: ($info | get --optional version | default "") } }
+    $deps | items {|name, info| { name: $name, version: ($info | get --optional version | default "") } }
 }
 # ─────────────────────────────────────────────────────────────────────────────
 # Homebrew
@@ -66,7 +73,7 @@ export def capture-pnpm-globals [] {
 export def capture-brew-packages [] {
     if (which brew | is-empty) { return null }
     let result = (^brew list --versions | complete)
-    if ($result.exit_code != 0) { return null }
+    if $result.exit_code != 0 { return null }
     $result.stdout | lines | where $it != "" | parse "{name} {version}" | default "" version
 }
 # ─────────────────────────────────────────────────────────────────────────────
@@ -76,23 +83,39 @@ export def capture-brew-packages [] {
 # Returns {added: [...], removed: [...], changed: [...]} where each item is:
 #   {name, old, new}
 export def diff-package-lists [old: list<any>, new: list<any>] {
-    let old_map = ($old | default [] | reduce -f {} {|it, acc| $acc | insert $it.name $it.version })
-    let new_map = ($new | default [] | reduce -f {} {|it, acc| $acc | insert $it.name $it.version })
-    let added = ($new_map | items { |name, ver| { name: $name, old: "", new: $ver } } | where { |it| not ($it.name in ($old_map | columns)) })
-    let removed = ($old_map | items { |name, ver| { name: $name, old: $ver, new: "" } } | where { |it| not ($it.name in ($new_map | columns)) })
-    let changed = ($new_map | items { |name, ver| { name: $name, old: ($old_map | get --optional $name | default ""), new: $ver } } | where { |it| ($it.old != "") and ($it.old != $it.new) })
-    {
-        added: $added
-        removed: $removed
-        changed: $changed
-    }
+    let old_map = (
+        $old
+        | default []
+        | reduce -f {} {|it, acc| $acc | insert $it.name $it.version }
+    )
+    let new_map = (
+        $new
+        | default []
+        | reduce -f {} {|it, acc| $acc | insert $it.name $it.version }
+    )
+    let added = (
+        $new_map
+        | items {|name, ver| { name: $name, old: "", new: $ver } }
+        | where {|it| not ($it.name in ($old_map | columns)) }
+    )
+    let removed = (
+        $old_map
+        | items {|name, ver| { name: $name, old: $ver, new: "" } }
+        | where {|it| not ($it.name in ($new_map | columns)) }
+    )
+    let changed = (
+        $new_map
+        | items {|name, ver| { name: $name, old: ($old_map | get --optional $name | default ""), new: $ver } }
+        | where {|it| ($it.old != "") and ($it.old != $it.new) }
+    )
+    {added: $added, removed: $removed, changed: $changed}
 }
 # ─────────────────────────────────────────────────────────────────────────────
 # Pretty-print helpers
 # ─────────────────────────────────────────────────────────────────────────────
 # Print a package diff returned by diff-package-lists.
 export def print-package-diff [diff: record, title: string] {
-    let total = ($diff.added | length) + ($diff.removed | length) + ($diff.changed | length)
+    let total = $diff.added | length) + ($diff.removed | length) + ($diff.changed | length
     if $total == 0 { return }
     header $title
     for pkg in $diff.added { success $"  + ($pkg.name) ($pkg.new)" }
@@ -103,7 +126,10 @@ export def print-package-diff [diff: record, title: string] {
 export def print-nix-diff [lines: list<string>, title: string] {
     if ($lines | is-empty) { return }
     # Filter out empty lines and lines with no actual change indicator
-    let meaningful = ($lines | where { |it| ($it | str contains "→") or ($it | str contains "+") or ($it | str contains "-") })
+    let meaningful = (
+        $lines
+        | where {|it| ($it | str contains "→") or ($it | str contains "+") or ($it | str contains "-") }
+    )
     if ($meaningful | is-empty) { return }
     header $title
     for line in $meaningful {
@@ -130,7 +156,7 @@ export def log-rebuild-summary [sections: list<string>, --log-file: string] {
         $log_file
     }
     mkdir ($file | path dirname)
-    let timestamp = (date now | format date "%Y-%m-%d %H:%M:%S")
+    let timestamp = date now | format date "%Y-%m-%d %H:%M:%S"
     let sep = "═══════════════════════════════════════════════════════════════════════════════"
     let lines = [
         $sep

--- a/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
+++ b/Configs/scripts/.local/bin/nu_modules/version_tracker.nu
@@ -35,16 +35,9 @@ export def diff-nix-closures [old_path: string, new_path: string] {
 # Return a list of {name, version} records for managed pnpm global project packages.
 export def capture-pnpm-globals [] {
     if (which pnpm | is-empty) { return null }
-    let runtime_dir = (
-        $env.XDG_DATA_HOME?
-        | default ($env.HOME | path join ".local/share")
-        | path join "pnpm-global"
-    )
+    let runtime_dir = ($env.XDG_DATA_HOME? | default ($env.HOME | path join ".local/share") | path join "pnpm-global")
     if not ($runtime_dir | path join "package.json" | path exists) { return null }
-    let result = (
-        ^bash -lc 'cd "${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global" && pnpm list --json'
-        | complete
-    )
+    let result = (^bash -lc 'cd "${XDG_DATA_HOME:-$HOME/.local/share}/pnpm-global" && pnpm list --json' | complete)
     if $result.exit_code != 0 { return null }
     let parsed = try {
         $result.stdout | from json
@@ -83,32 +76,16 @@ export def capture-brew-packages [] {
 # Returns {added: [...], removed: [...], changed: [...]} where each item is:
 #   {name, old, new}
 export def diff-package-lists [old: list<any>, new: list<any>] {
-    let old_map = (
-        $old
-        | default []
-        | reduce -f {} {|it, acc| $acc | insert $it.name $it.version }
-    )
-    let new_map = (
-        $new
-        | default []
-        | reduce -f {} {|it, acc| $acc | insert $it.name $it.version }
-    )
-    let added = (
-        $new_map
-        | items {|name, ver| { name: $name, old: "", new: $ver } }
-        | where {|it| not ($it.name in ($old_map | columns)) }
-    )
-    let removed = (
-        $old_map
-        | items {|name, ver| { name: $name, old: $ver, new: "" } }
-        | where {|it| not ($it.name in ($new_map | columns)) }
-    )
-    let changed = (
-        $new_map
-        | items {|name, ver| { name: $name, old: ($old_map | get --optional $name | default ""), new: $ver } }
-        | where {|it| ($it.old != "") and ($it.old != $it.new) }
-    )
-    {added: $added, removed: $removed, changed: $changed}
+    let old_map = ($old | default [] | reduce -f {} {|it, acc| $acc | insert $it.name $it.version })
+    let new_map = ($new | default [] | reduce -f {} {|it, acc| $acc | insert $it.name $it.version })
+    let added = ($new_map | items {|name, ver| { name: $name, old: "", new: $ver } } | where {|it| not ($it.name in ($old_map | columns)) })
+    let removed = ($old_map | items {|name, ver| { name: $name, old: $ver, new: "" } } | where {|it| not ($it.name in ($new_map | columns)) })
+    let changed = ($new_map | items {|name, ver| { name: $name, old: ($old_map | get --optional $name | default ""), new: $ver } } | where {|it| ($it.old != "") and ($it.old != $it.new) })
+    {
+        added: $added
+        removed: $removed
+        changed: $changed
+    }
 }
 # ─────────────────────────────────────────────────────────────────────────────
 # Pretty-print helpers
@@ -129,10 +106,7 @@ export def print-package-diff [diff: record, title: string] {
 export def print-nix-diff [lines: list<string>, title: string] {
     if ($lines | is-empty) { return }
     # Filter out empty lines and lines with no actual change indicator
-    let meaningful = (
-        $lines
-        | where {|it| ($it | str contains "→") or ($it | str contains "+") or ($it | str contains "-") }
-    )
+    let meaningful = ($lines | where {|it| ($it | str contains "→") or ($it | str contains "+") or ($it | str contains "-") })
     if ($meaningful | is-empty) { return }
     header $title
     for line in $meaningful {

--- a/Configs/scripts/.local/bin/rebuild
+++ b/Configs/scripts/.local/bin/rebuild
@@ -119,6 +119,12 @@ def main [
     --add-preset: string  # Add a preset to machine.nix (e.g. ironclaw)
     --remove-preset: string  # Remove a preset from machine.nix
 ] {
+    let invoked_by_dotfiles_cli = ("DOTFILES_CLI" in $env) and $env.DOTFILES_CLI == "1"
+
+    if not $invoked_by_dotfiles_cli {
+        warn "Direct use of `rebuild` is deprecated. Use `dotfiles rebuild` instead."
+    }
+
     if $force and not $latest {
         err "--force requires --latest"
         exit 1

--- a/Configs/secretspec/secretspec.toml
+++ b/Configs/secretspec/secretspec.toml
@@ -7,7 +7,7 @@ dotenv = "dotenv:.env.dotfiles" # Store the `OP_SERVICE_ACCOUNT_TOKEN` here. Thi
 keyring = "keyring://"
 op-interactive = "op://Sensitive/ServiceAccounts"
 op-token = { uri = "op+token://Development/Dotfiles", depends_on = [
-  { secret = "OP_SERVICE_ACCOUNT_TOKEN" },
+	{ secret = "OP_SERVICE_ACCOUNT_TOKEN" },
 ] }
 
 [profiles.default.defaults]
@@ -17,11 +17,11 @@ required = true
 [profiles.default.OP_SERVICE_ACCOUNT_TOKEN]
 description = "1Password service account token for automated access"
 providers = [
-  "dotenv",
-  "keyring",
-  { provider = "op-interactive", path = [
-    "Development",
-  ], key = "READ" },
+	"dotenv",
+	"keyring",
+	{ provider = "op-interactive", path = [
+		"Development",
+	], key = "READ" },
 ]
 
 [profiles.default.GITHUB_TOKEN]

--- a/Configs/shell/.config/shell/env.sh
+++ b/Configs/shell/.config/shell/env.sh
@@ -154,7 +154,8 @@ fi
 # Primary source: 1Password via secretspec (use `ssr codex ...`)
 # Fallback: ~/.codex/secrets.env for offline use
 if [ -f ~/.codex/secrets.env ]; then
-    export XIAOMI_MIMO_API_KEY=$(grep '^XIAOMI_MIMO_API_KEY=' ~/.codex/secrets.env | cut -d'=' -f2)
-    export OLLAMA_CLOUD_API_KEY=$(grep '^OLLAMA_CLOUD_API_KEY=' ~/.codex/secrets.env | cut -d'=' -f2)
-    export OLLAMA_API_KEY=$(grep '^OLLAMA_API_KEY=' ~/.codex/secrets.env | cut -d'=' -f2-)
+	XIAOMI_MIMO_API_KEY=$(grep '^XIAOMI_MIMO_API_KEY=' ~/.codex/secrets.env | cut -d'=' -f2)
+	OLLAMA_CLOUD_API_KEY=$(grep '^OLLAMA_CLOUD_API_KEY=' ~/.codex/secrets.env | cut -d'=' -f2)
+	OLLAMA_API_KEY=$(grep '^OLLAMA_API_KEY=' ~/.codex/secrets.env | cut -d'=' -f2-)
+	export XIAOMI_MIMO_API_KEY OLLAMA_CLOUD_API_KEY OLLAMA_API_KEY
 fi

--- a/Hooks/nix/post.sh
+++ b/Hooks/nix/post.sh
@@ -455,7 +455,7 @@ fi
 
 # ---------------------------------------------------------------------------
 # Compile the dotfiles CLI binary after a successful rebuild.
-# This ensures 'dotfiles' and 'df' are always in sync with the source.
+# This ensures 'dotfiles' and 'dot' are always in sync with the source.
 # ---------------------------------------------------------------------------
 if [ "$REBUILD_EXIT" -eq 0 ]; then
 	DOTFILES_REPO_DIR="${DOTFILES_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)}"

--- a/cli/commands/rebuild.ts
+++ b/cli/commands/rebuild.ts
@@ -41,6 +41,9 @@ export const rebuildCommand = new Command()
 		printHeader("Rebuilding system configuration");
 		const { code, success } = await runCommand([script, ...args], {
 			cwd: dotfilesDir,
+			env: {
+				DOTFILES_CLI: "1",
+			},
 		});
 
 		if (!success) {

--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -10,16 +10,16 @@ Codex supports Xiaomi MiMo, local Ollama, and Ollama Cloud models via custom pro
 
 ## Available Profiles
 
-| Profile | Provider | Model | Description |
-|---------|----------|-------|-------------|
-| `mimo` | Xiaomi MiMo | mimo-v2.5-pro | Flagship reasoning model (1M context) |
-| `mimo-flash` | Xiaomi MiMo | mimo-v2-flash | Fast, low-cost model |
-| `mimo-omni` | Xiaomi MiMo | mimo-v2.5 | Multimodal (text, image, audio, video) |
-| `ollama-gemma4` | Ollama (local) | gemma4:26b | Local Gemma4 26B |
-| `ollama-deepseek` | Ollama (local) | deepseek-r1:latest | Local DeepSeek R1 |
-| `ollama-gemma3` | Ollama (local) | gemma3:27b | Local Gemma3 27B |
-| `cloud-kimi` | Ollama Cloud | kimi-k2.5 | Kimi K2.5 via Ollama Cloud |
-| `cloud-glm` | Ollama Cloud | glm-5.1 | GLM 5.1 via Ollama Cloud |
+| Profile           | Provider       | Model              | Description                            |
+| ----------------- | -------------- | ------------------ | -------------------------------------- |
+| `mimo`            | Xiaomi MiMo    | mimo-v2.5-pro      | Flagship reasoning model (1M context)  |
+| `mimo-flash`      | Xiaomi MiMo    | mimo-v2-flash      | Fast, low-cost model                   |
+| `mimo-omni`       | Xiaomi MiMo    | mimo-v2.5          | Multimodal (text, image, audio, video) |
+| `ollama-gemma4`   | Ollama (local) | gemma4:26b         | Local Gemma4 26B                       |
+| `ollama-deepseek` | Ollama (local) | deepseek-r1:latest | Local DeepSeek R1                      |
+| `ollama-gemma3`   | Ollama (local) | gemma3:27b         | Local Gemma3 27B                       |
+| `cloud-kimi`      | Ollama Cloud   | kimi-k2.5          | Kimi K2.5 via Ollama Cloud             |
+| `cloud-glm`       | Ollama Cloud   | glm-5.1            | GLM 5.1 via Ollama Cloud               |
 
 ## Usage
 
@@ -42,6 +42,7 @@ ssload
 ```
 
 Keys are in `secretspec.toml` → `op://Development/dotfiles` vault (`ai` path):
+
 - `XIAOMI_MIMO_API_KEY`
 - `OLLAMA_CLOUD_API_KEY`
 


### PR DESCRIPTION
## Summary

Adds a deprecation notice when the legacy `rebuild` script is invoked directly and points users to `dotfiles rebuild` instead.

## Changes

- Prints a warning for direct `rebuild` usage:
  - `Direct use of rebuild is deprecated. Use dotfiles rebuild instead.`
- Suppresses that warning when `dotfiles rebuild` delegates to the same script.
- Updates the nix post-hook comment from the old `df` alias to the current `dot` alias.

## Verification

- [x] `dprint check --config Configs/dprint/dprint.json Configs/scripts/.local/bin/rebuild Hooks/nix/post.sh cli/commands/rebuild.ts`
- [x] `shellcheck setup setup-tuckr-symlink.sh Hooks/*/post.sh`
- [x] `cd cli && deno task check:all`
- [x] `cd cli && deno task test`

Note: full-repo `dprint check --config Configs/dprint/dprint.json` currently reports unrelated pre-existing formatting drift in Nushell/SecretsSpec files, so this PR verified formatting for the touched files directly.
