### PR TITLE
test(cli): enforce coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,9 @@ jobs:
         run: |
           cd cli && deno task lint
 
-      - name: 🧪 test CLI (deno test)
+      - name: 🧪 test CLI with coverage threshold
         run: |
-          cd cli && deno task test
+          cd cli && deno task coverage
 
       - name: 🏗️ compile CLI binary (deno compile)
         run: |

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -3,3 +3,4 @@ dotfiles
 
 # Deno
 .deno/
+coverage/

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -9,6 +9,7 @@
 		"compile": "deno compile --allow-all --output ../Configs/scripts/.local/bin/dotfiles main.ts",
 		"compile:dev": "deno compile --allow-all --output dotfiles main.ts",
 		"test": "deno test --allow-all",
+		"coverage": "rm -rf coverage && DOTFILES_CLI_COVERAGE_DIR=coverage deno test --allow-all --coverage=coverage && deno coverage --ignore=commands --lcov --output=coverage/lcov.info coverage && deno run --allow-read --allow-env test/coverage_threshold.ts coverage/lcov.info 90",
 		"lint": "deno run -A npm:oxlint@1.67.0 . && deno lint",
 		"lint:oxlint": "deno run -A npm:oxlint@1.67.0 .",
 		"lint:deno": "deno lint",
@@ -26,7 +27,8 @@
 		"@std/fs": "jsr:@std/fs@^1.0.0",
 		"@std/path": "jsr:@std/path@^1.0.0",
 		"@std/toml": "jsr:@std/toml@^1.0.0",
-		"@std/fmt": "jsr:@std/fmt@^1.0.0"
+		"@std/fmt": "jsr:@std/fmt@^1.0.0",
+		"@std/testing": "jsr:@std/testing@^1.0.0"
 	},
 	"lint": {
 		"rules": {

--- a/cli/deno.lock
+++ b/cli/deno.lock
@@ -6,11 +6,16 @@
     "jsr:@cliffy/internal@1.1.0": "1.1.0",
     "jsr:@cliffy/table@1.1.0": "1.1.0",
     "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/fmt@^1.0.9": "1.0.10",
-    "jsr:@std/fs@1": "1.0.23",
-    "jsr:@std/internal@^1.0.12": "1.0.13",
-    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/fs@1": "1.0.24",
+    "jsr:@std/fs@^1.0.24": "1.0.24",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/path@1": "1.1.5",
     "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/path@^1.1.5": "1.1.5",
+    "jsr:@std/testing@1": "1.0.19",
     "jsr:@std/text@^1.0.17": "1.0.18",
     "npm:oxlint@1.67.0": "1.67.0"
   },
@@ -44,7 +49,7 @@
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/fmt@1.0.10": {
@@ -53,17 +58,42 @@
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
-        "jsr:@std/internal",
+        "jsr:@std/internal@^1.0.12",
         "jsr:@std/path@^1.1.4"
+      ]
+    },
+    "@std/fs@1.0.24": {
+      "integrity": "f3061b45b81673a2bece689da041df32d174be064c89eb6397fb5718d3fb7877",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.5"
       ]
     },
     "@std/internal@1.0.13": {
       "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
     },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/path@1.1.5": {
+      "integrity": "ccea00982ea28c36becaf6e62f855406c76a8c32d462f66f415bbb7d83a271bc",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    },
+    "@std/testing@1.0.19": {
+      "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/fs@^1.0.24",
+        "jsr:@std/internal@^1.0.14",
+        "jsr:@std/path@^1.1.5"
       ]
     },
     "@std/text@1.0.18": {
@@ -200,6 +230,7 @@
       "jsr:@std/fmt@1",
       "jsr:@std/fs@1",
       "jsr:@std/path@1",
+      "jsr:@std/testing@1",
       "jsr:@std/toml@1"
     ]
   }

--- a/cli/test/__snapshots__/cli_snapshot_test.ts.snap
+++ b/cli/test/__snapshots__/cli_snapshot_test.ts.snap
@@ -1,0 +1,261 @@
+export const snapshot = {};
+
+snapshot[`top-level help output is stable 1`] = `
+"
+Usage:   dotfiles
+Version: 0.1.0   
+
+Description:
+
+  Manage your dotfiles — setup, rebuild, reload, and more.           
+                                                                     
+  Run 'dotfiles help <command>' for detailed usage of any subcommand.
+
+Options:
+
+  -h, --help     - Show this help.                            
+  -V, --version  - Show the version number for this program.  
+
+Commands:
+
+  setup                  - Initial dotfiles setup — install Nix, clone repo, deploy groups         
+  rebuild                - Rebuild system configuration (nix-darwin switch or home-manager switch) 
+  reload                 - Reload tuckr configuration groups (non-destructive, re-applies symlinks)
+  doctor                 - Run preflight checks without changing the machine                       
+  groups                 - Manage configuration groups — list, inspect, deploy, and undeploy       
+  machine                - Manage machine.nix — inspect and modify system configuration            
+  nix                    - Manage nix configuration directly                                       
+  env                    - Manage environment configuration and secrets                            
+  pnpm                   - Manage pnpm global packages managed by dotfiles                         
+  uninstall              - Completely remove dotfiles installation (nix, symlinks, state)          
+  reset                  - Uninstall and re-setup dotfiles from scratch                            
+  self                   - Manage the dotfiles CLI binary                                          
+  completion  <shell>    - Generate shell completion providers                                     
+  version                - Print CLI version and environment info                                  
+  help        [command]  - Show this help or the help of a sub-command.                            
+
+"
+`;
+
+snapshot[`completion output is stable > bash 1`] = `
+'# bash completion for dotfiles / dot
+# Install with:
+#   mkdir -p ~/.local/share/bash-completion/completions
+#   dot completion bash > ~/.local/share/bash-completion/completions/dot
+#   dot completion bash > ~/.local/share/bash-completion/completions/dotfiles
+
+_dotfiles_completion() {
+  local cur command
+  COMPREPLY=()
+  cur="\${COMP_WORDS[COMP_CWORD]}"
+  command="\${COMP_WORDS[1]}"
+
+  if [[ COMP_CWORD -eq 1 ]]; then
+    COMPREPLY=( \$(compgen -W "setup rebuild reload doctor groups machine nix env pnpm uninstall reset self version help completion --help --version" -- "\$cur") )
+    return 0
+  fi
+
+  case "\$command" in
+    completion)
+      if [[ COMP_CWORD -eq 2 && "\$cur" != --* ]]; then
+        COMPREPLY=( \$(compgen -W "bash nushell --help" -- "\$cur") )
+        return 0
+      fi
+      ;;
+    env)
+      if [[ COMP_CWORD -eq 2 && "\$cur" != --* ]]; then
+        COMPREPLY=( \$(compgen -W "doctor secrets template --help" -- "\$cur") )
+        return 0
+      fi
+      ;;
+    groups)
+      if [[ COMP_CWORD -eq 2 && "\$cur" != --* ]]; then
+        COMPREPLY=( \$(compgen -W "list info deploy undeploy --help" -- "\$cur") )
+        return 0
+      fi
+      ;;
+    machine)
+      if [[ COMP_CWORD -eq 2 && "\$cur" != --* ]]; then
+        COMPREPLY=( \$(compgen -W "config set-lite set-desktop set-always-on add-preset remove-preset regenerate --help" -- "\$cur") )
+        return 0
+      fi
+      ;;
+    nix)
+      if [[ COMP_CWORD -eq 2 && "\$cur" != --* ]]; then
+        COMPREPLY=( \$(compgen -W "doctor flake machine --help" -- "\$cur") )
+        return 0
+      fi
+      ;;
+    pnpm)
+      if [[ COMP_CWORD -eq 2 && "\$cur" != --* ]]; then
+        COMPREPLY=( \$(compgen -W "sync update list status --help" -- "\$cur") )
+        return 0
+      fi
+      ;;
+    self)
+      if [[ COMP_CWORD -eq 2 && "\$cur" != --* ]]; then
+        COMPREPLY=( \$(compgen -W "install --help" -- "\$cur") )
+        return 0
+      fi
+      ;;
+  esac
+
+  case "\$command" in
+    completion) COMPREPLY=( \$(compgen -W "--help" -- "\$cur") ) ; return 0 ;;
+    doctor) COMPREPLY=( \$(compgen -W "--help --verify" -- "\$cur") ) ; return 0 ;;
+    rebuild) COMPREPLY=( \$(compgen -W "--help --groups --skip-check --update --brew --lite --no-lite --desktop --no-desktop --latest --force --rebuild-os --always-on --no-always-on --add-preset --remove-preset --dry-run" -- "\$cur") ) ; return 0 ;;
+    reload) COMPREPLY=( \$(compgen -W "--help --force --no-hooks --dry-run" -- "\$cur") ) ; return 0 ;;
+    self) COMPREPLY=( \$(compgen -W "--help" -- "\$cur") ) ; return 0 ;;
+    setup) COMPREPLY=( \$(compgen -W "--help" -- "\$cur") ) ; return 0 ;;
+  esac
+}
+
+complete -F _dotfiles_completion dot
+complete -F _dotfiles_completion dotfiles
+
+'
+`;
+
+snapshot[`completion output is stable > nushell 1`] = `
+'# Nushell completions for dotfiles / dot
+# Install with:
+#   mkdir ~/.config/nushell/completions
+#   dot completion nushell | save -f ~/.config/nushell/completions/dot-completions.nu
+#   use ~/.config/nushell/completions/dot-completions.nu *
+
+export def "nu-complete dot commands" [] {
+  [setup rebuild reload doctor groups machine nix env pnpm uninstall reset self version help completion]
+}
+
+export def "nu-complete dot completion shells" [] {
+  [bash nushell]
+}
+
+export extern "dot" [
+  command?: string@"nu-complete dot commands"
+  ...args: string
+]
+
+export extern "dotfiles" [
+  command?: string@"nu-complete dot commands"
+  ...args: string
+]
+
+export extern "dot completion" [
+  shell?: string@"nu-complete dot completion shells"
+]
+
+export extern "dot rebuild" [
+  --groups: string
+  --skip-check
+  --update
+  --brew
+  --lite
+  --no-lite
+  --desktop
+  --no-desktop
+  --latest
+  --force
+  --rebuild-os
+  --always-on
+  --no-always-on
+  --add-preset: string
+  --remove-preset: string
+  --dry-run
+]
+
+export extern "dot reload" [
+  --force
+  --no-hooks
+  --dry-run
+]
+
+export extern "dot doctor" [
+  --verify
+]
+
+export extern "dot self install" [
+  --bin-dir: string
+]
+
+'
+`;
+
+snapshot[`version output is stable 1`] = `
+"dotfiles v0.1.0
+Platform: <platform>
+Repo:     <repo>
+Git:      <git>
+Nix:      <nix>
+"
+`;
+
+snapshot[`safe command outputs are stable > groups list 1`] = `
+"
+==> Available configuration groups
+  agents         AI agent configurations and shared skills/extensions. Manages ~/.config/agents/, ~/.config/opencode/, and ~/.agents/ (skills, extensions).
+  atuin          Atuin shell history manager — session-first up-arrow, global Ctrl-R.
+  bash           Bash shell configuration and interactive shell defaults.
+  codex          codex
+  direnv         direnv configuration for per-directory environment management.
+  dprint         Shared dprint formatter configuration for repository tooling.
+  ghostty        Ghostty terminal emulator configuration.
+  git            Portable Git includes and shared config files managed under ~/.config/git/.
+  helix          Helix editor configuration, including optional custom Steel tooling.
+  ironclaw       Ironclaw agent runtime configuration and environment.
+  kdl            KDL formatter configuration used by editor and tooling workflows.
+  lazygit        Lazygit terminal UI configuration for Git workflows.
+  nix            Nix flake, nix-darwin, and home-manager configuration.
+  nushell        Nushell configuration and generated vendor autoload integrations.
+  pnpm           Managed global pnpm manifest and lockfile sync.
+  scripts        Bootstrap and maintenance scripts used throughout setup and CI.
+  secretspec     Declarative secrets via SecretSpec + 1Password. Replaces ~/.env.dotfiles.
+  shell          Shared shell environment configuration and common aliases.
+  yazi           Yazi terminal file manager configuration.
+  zellij         Zellij terminal multiplexer configuration and layouts.
+  zsh            Zsh compatibility configuration for POSIX shells and external tools.
+"
+`;
+
+snapshot[`safe command outputs are stable > groups info 1`] = `
+"
+==> Group: bash
+  Description: Bash shell configuration and interactive shell defaults.
+  Platforms:   all
+  Phase:       normal
+  Presets:     core, dev, workstation, ci
+  Depends on:  none
+"
+`;
+
+snapshot[`safe command outputs are stable > setup dry run 1`] = `
+"Running: <repo>/setup --preset ci --skip-nix --dry-run --no-confirm
+
+╔════════════════════════════════════════╗
+║                                        ║
+║      Dotfiles Setup Script             ║
+║                                        ║
+╚════════════════════════════════════════╝
+
+→ Platform detected: <platform>
+→ Running from within dotfiles repository: <repo>
+→ Using preset 'ci': Minimal non-interactive setup intended for CI and containers.
+→ Lite mode enabled: GUI-heavy applications will be skipped
+==> Setup plan
+  • Platform: <platform>
+  • Preset: ci
+  • Reuse repository: <repo>
+  • Nix: Skip Nix installation (--skip-nix)
+  • Temporary bootstrap tools: <tools>
+  • GUI applications: CLI-focused / GUI-heavy applications skipped
+  • Expected duration: 5–10 minutes
+  • Deploy groups: scripts, nix, bash, direnv, dprint, git, kdl, shell, zellij, zsh, nushell
+  • Hooks that will run: nix, bash, git, nushell
+
+"
+`;
+
+snapshot[`invalid rebuild flag combinations fail 1`] = `
+"✗ --force requires --latest
+"
+`;

--- a/cli/test/cli_snapshot_test.ts
+++ b/cli/test/cli_snapshot_test.ts
@@ -1,0 +1,159 @@
+import { assertEquals } from "@std/assert";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { assertSnapshot } from "@std/testing/snapshot";
+
+const cliDir = dirname(dirname(fromFileUrl(import.meta.url)));
+const repoDir = dirname(cliDir);
+const mainPath = join(cliDir, "main.ts");
+
+interface CliResult {
+	code: number;
+	stderr: string;
+	stdout: string;
+}
+
+function stripAnsi(value: string): string {
+	let result = "";
+	let index = 0;
+
+	while (index < value.length) {
+		if (value.charCodeAt(index) === 27 && value[index + 1] === "[") {
+			index += 2;
+
+			while (index < value.length && value[index] !== "m") {
+				index++;
+			}
+
+			index++;
+			continue;
+		}
+
+		result += value[index];
+		index++;
+	}
+
+	return result;
+}
+
+function scrubOutput(value: string): string {
+	return stripAnsi(value)
+		.split("\n")
+		.map((line) => {
+			if (line.startsWith("Platform: ")) return "Platform: <platform>";
+			if (line.includes("Platform detected: ")) {
+				return line.replace(
+					/Platform detected: .*/,
+					"Platform detected: <platform>",
+				);
+			}
+			if (line.includes("• Platform: ")) {
+				return line.replace(/• Platform: .*/, "• Platform: <platform>");
+			}
+			if (line.startsWith("Git: ")) return "Git:      <git>";
+			if (line.startsWith("Nix: ")) return "Nix:      <nix>";
+			if (line.includes("Temporary bootstrap tools: ")) {
+				return line.replace(
+					/Temporary bootstrap tools: .*/,
+					"Temporary bootstrap tools: <tools>",
+				);
+			}
+			if (line.includes("Rosetta 2 is already installed")) return "";
+
+			return line;
+		})
+		.join("\n")
+		.replaceAll("\n\n→ Using preset", "\n→ Using preset")
+		.replaceAll(/\n{3,}/g, "\n\n");
+}
+
+async function runCli(args: string[]): Promise<CliResult> {
+	const coverageDir = Deno.env.get("DOTFILES_CLI_COVERAGE_DIR");
+	const denoArgs = [
+		"run",
+		"--allow-all",
+	];
+
+	if (coverageDir) {
+		denoArgs.push(`--coverage=${coverageDir}`);
+	}
+
+	denoArgs.push(mainPath, ...args);
+
+	const command = new Deno.Command(Deno.execPath(), {
+		args: denoArgs,
+		cwd: cliDir,
+		env: {
+			DOTFILES_DIR: repoDir,
+			HOME: Deno.env.get("HOME") ?? repoDir,
+			NO_COLOR: "1",
+		},
+		stderr: "piped",
+		stdout: "piped",
+	});
+	const output = await command.output();
+	const decoder = new TextDecoder();
+
+	return {
+		code: output.code,
+		stderr: scrubOutput(
+			decoder.decode(output.stderr).replaceAll(repoDir, "<repo>"),
+		),
+		stdout: scrubOutput(
+			decoder.decode(output.stdout).replaceAll(repoDir, "<repo>"),
+		),
+	};
+}
+
+async function assertCliSnapshot(t: Deno.TestContext, args: string[]) {
+	const result = await runCli(args);
+
+	assertEquals(result.code, 0);
+	await assertSnapshot(t, result.stdout);
+	assertEquals(result.stderr, "");
+}
+
+Deno.test("top-level help output is stable", async (t) => {
+	await assertCliSnapshot(t, ["--help"]);
+});
+
+Deno.test("completion output is stable", async (t) => {
+	await t.step("bash", async (step) => {
+		await assertCliSnapshot(step, ["completion", "bash"]);
+	});
+
+	await t.step("nushell", async (step) => {
+		await assertCliSnapshot(step, ["completion", "nushell"]);
+	});
+});
+
+Deno.test("version output is stable", async (t) => {
+	await assertCliSnapshot(t, ["version", "--verbose"]);
+});
+
+Deno.test("safe command outputs are stable", async (t) => {
+	await t.step("groups list", async (step) => {
+		await assertCliSnapshot(step, ["groups", "list"]);
+	});
+
+	await t.step("groups info", async (step) => {
+		await assertCliSnapshot(step, ["groups", "info", "bash"]);
+	});
+
+	await t.step("setup dry run", async (step) => {
+		await assertCliSnapshot(step, [
+			"setup",
+			"--dry-run",
+			"--preset",
+			"ci",
+			"--skip-nix",
+			"--no-confirm",
+		]);
+	});
+});
+
+Deno.test("invalid rebuild flag combinations fail", async (t) => {
+	const result = await runCli(["rebuild", "--force"]);
+
+	assertEquals(result.code, 1);
+	await assertSnapshot(t, result.stderr);
+});

--- a/cli/test/config_output_test.ts
+++ b/cli/test/config_output_test.ts
@@ -1,0 +1,54 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import {
+	colors,
+	printError,
+	printHeader,
+	printInfo,
+	printSuccess,
+	printWarning,
+} from "../lib/config.ts";
+
+function captureOutput(fn: () => void) {
+	const logs: string[] = [];
+	const errors: string[] = [];
+	const originalLog = console.log;
+	const originalError = console.error;
+
+	try {
+		console.log = (value: unknown) => logs.push(String(value));
+		console.error = (value: unknown) => errors.push(String(value));
+		fn();
+	} finally {
+		console.log = originalLog;
+		console.error = originalError;
+	}
+
+	return { errors, logs };
+}
+
+Deno.test("color helpers wrap text with ansi escapes", () => {
+	assertEquals(colors.red("x"), "\x1b[0;31mx\x1b[0m");
+	assertEquals(colors.green("x"), "\x1b[0;32mx\x1b[0m");
+	assertEquals(colors.yellow("x"), "\x1b[1;33mx\x1b[0m");
+	assertEquals(colors.blue("x"), "\x1b[0;34mx\x1b[0m");
+	assertEquals(colors.cyan("x"), "\x1b[0;36mx\x1b[0m");
+	assertEquals(colors.bold("x"), "\x1b[1mx\x1b[0m");
+});
+
+Deno.test("print helpers write expected channels", () => {
+	const output = captureOutput(() => {
+		printHeader("header");
+		printSuccess("success");
+		printWarning("warning");
+		printInfo("info");
+		printError("error");
+	});
+
+	assertEquals(output.logs.length, 4);
+	assertEquals(output.errors.length, 1);
+	assertStringIncludes(output.logs.join("\n"), "header");
+	assertStringIncludes(output.logs.join("\n"), "success");
+	assertStringIncludes(output.logs.join("\n"), "warning");
+	assertStringIncludes(output.logs.join("\n"), "info");
+	assertStringIncludes(output.errors.join("\n"), "error");
+});

--- a/cli/test/config_test.ts
+++ b/cli/test/config_test.ts
@@ -1,14 +1,74 @@
 import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
 import {
+	commandExists,
+	detectArch,
 	detectPlatform,
 	discoverGroups,
+	findExecutable,
+	formatCommand,
+	loadGroupMetadata,
+	machineConfigPath,
+	nixSystem,
 	resolveDotfilesDir,
+	resolveNixConfigDir,
+	runCommand,
 } from "../lib/config.ts";
 
-Deno.test("detectPlatform returns a supported platform label", () => {
+Deno.test("platform helpers return supported labels", () => {
 	const platform = detectPlatform();
+	const system = nixSystem();
 
 	assert(["macos", "linux", "windows", "bsd"].includes(platform));
+	assert(system.startsWith(`${detectArch()}-`));
+});
+
+Deno.test("resolveDotfilesDir honors DOTFILES_DIR", async () => {
+	const previous = Deno.env.get("DOTFILES_DIR");
+	const tempDir = await Deno.makeTempDir();
+
+	try {
+		Deno.env.set("DOTFILES_DIR", tempDir);
+		assertEquals(await resolveDotfilesDir(), tempDir);
+	} finally {
+		if (previous === undefined) {
+			Deno.env.delete("DOTFILES_DIR");
+		} else {
+			Deno.env.set("DOTFILES_DIR", previous);
+		}
+
+		await Deno.remove(tempDir, { recursive: true });
+	}
+});
+
+Deno.test("resolveDotfilesDir walks up from cwd", async () => {
+	const previousEnv = Deno.env.get("DOTFILES_DIR");
+	const previousCwd = Deno.cwd();
+	const tempDir = await Deno.makeTempDir();
+	const nestedDir = join(tempDir, "a/b/c");
+
+	try {
+		Deno.env.delete("DOTFILES_DIR");
+		await Deno.mkdir(join(tempDir, "Configs"));
+		await Deno.writeTextFile(join(tempDir, "setup"), "#!/usr/bin/env bash\n");
+		await Deno.mkdir(nestedDir, { recursive: true });
+		Deno.chdir(nestedDir);
+
+		assertEquals(
+			await Deno.realPath(await resolveDotfilesDir()),
+			await Deno.realPath(tempDir),
+		);
+	} finally {
+		Deno.chdir(previousCwd);
+
+		if (previousEnv === undefined) {
+			Deno.env.delete("DOTFILES_DIR");
+		} else {
+			Deno.env.set("DOTFILES_DIR", previousEnv);
+		}
+
+		await Deno.remove(tempDir, { recursive: true });
+	}
 });
 
 Deno.test("discoverGroups finds repository config groups", async () => {
@@ -18,4 +78,106 @@ Deno.test("discoverGroups finds repository config groups", async () => {
 	assert(groups.length > 0);
 	assert(groups.includes("nix"));
 	assertEquals(groups, groups.toSorted());
+});
+
+Deno.test("discoverGroups returns empty when Configs is missing", async () => {
+	const tempDir = await Deno.makeTempDir();
+
+	try {
+		assertEquals(await discoverGroups(tempDir), []);
+	} finally {
+		await Deno.remove(tempDir, { recursive: true });
+	}
+});
+
+Deno.test("loadGroupMetadata parses metadata and applies defaults", async () => {
+	const tempDir = await Deno.makeTempDir();
+
+	try {
+		await Deno.mkdir(join(tempDir, "Configs"));
+		await Deno.writeTextFile(
+			join(tempDir, "Configs/example.group.toml"),
+			`description = "Example group"
+presets = ["core", "dev"]
+depends_on = shell editor
+phase = "late"
+platforms = ["macos", "linux"]
+ignored line
+`,
+		);
+
+		assertEquals(await loadGroupMetadata(tempDir, "example"), {
+			description: "Example group",
+			dependsOn: ["shell", "editor"],
+			phase: "late",
+			platforms: ["macos", "linux"],
+			presets: ["core", "dev"],
+		});
+
+		assertEquals(await loadGroupMetadata(tempDir, "missing"), {
+			description: "missing",
+			dependsOn: [],
+			phase: "normal",
+			platforms: [],
+			presets: [],
+		});
+	} finally {
+		await Deno.remove(tempDir, { recursive: true });
+	}
+});
+
+Deno.test("nix config and machine paths resolve", async () => {
+	const previousHome = Deno.env.get("HOME");
+	const homeDir = await Deno.makeTempDir();
+	const dotfilesDir = await Deno.makeTempDir();
+	const targetDir = await Deno.makeTempDir();
+
+	try {
+		Deno.env.set("HOME", homeDir);
+		let nixConfigDir = await resolveNixConfigDir(dotfilesDir);
+
+		assertEquals(nixConfigDir, join(dotfilesDir, "Configs/nix/.config/nix"));
+		assertEquals(
+			machineConfigPath(nixConfigDir),
+			join(nixConfigDir, "machine.nix"),
+		);
+
+		await Deno.mkdir(join(homeDir, ".config"));
+		await Deno.symlink(targetDir, join(homeDir, ".config/nix"));
+		nixConfigDir = await resolveNixConfigDir(dotfilesDir);
+
+		assertEquals(nixConfigDir, await Deno.realPath(targetDir));
+	} finally {
+		if (previousHome === undefined) {
+			Deno.env.delete("HOME");
+		} else {
+			Deno.env.set("HOME", previousHome);
+		}
+
+		await Deno.remove(homeDir, { recursive: true });
+		await Deno.remove(dotfilesDir, { recursive: true });
+		await Deno.remove(targetDir, { recursive: true });
+	}
+});
+
+Deno.test("command helpers handle success and failure", async () => {
+	assert(await commandExists(Deno.execPath()));
+	assert(!await commandExists("definitely-not-a-dotfiles-command"));
+	assert(await findExecutable("deno"));
+	assertEquals(await findExecutable("definitely-not-a-dotfiles-command"), null);
+
+	const result = await runCommand([
+		Deno.execPath(),
+		"eval",
+		"console.log(Deno.env.get('DOTFILES_TEST_VALUE'))",
+	], {
+		env: { DOTFILES_TEST_VALUE: "hello" },
+		stdout: "piped",
+	});
+
+	assertEquals(result, { code: 0, stdout: "hello\n", success: true });
+	assertEquals(
+		formatCommand(["dot", "groups", "info", "two words"]),
+		'dot groups info "two words"',
+	);
 });

--- a/cli/test/coverage_threshold.ts
+++ b/cli/test/coverage_threshold.ts
@@ -1,0 +1,43 @@
+import { assert } from "@std/assert";
+
+const [lcovPath, thresholdInput] = Deno.args;
+
+if (!lcovPath || !thresholdInput) {
+	console.error(
+		"Usage: deno run test/coverage_threshold.ts <lcov.info> <line-threshold>",
+	);
+	Deno.exit(2);
+}
+
+const threshold = Number(thresholdInput);
+
+if (!Number.isFinite(threshold)) {
+	console.error(`Invalid coverage threshold: ${thresholdInput}`);
+	Deno.exit(2);
+}
+
+const lcov = await Deno.readTextFile(lcovPath);
+let found = 0;
+let hit = 0;
+
+for (const line of lcov.split("\n")) {
+	if (line.startsWith("LF:")) {
+		found += Number(line.slice(3));
+	}
+
+	if (line.startsWith("LH:")) {
+		hit += Number(line.slice(3));
+	}
+}
+
+assert(found > 0, "Coverage report did not include any lines");
+
+const coverage = (hit / found) * 100;
+const formatted = coverage.toFixed(2);
+
+console.log(`Line coverage: ${formatted}% (${hit}/${found})`);
+
+if (coverage < threshold) {
+	console.error(`Line coverage ${formatted}% is below required ${threshold}%`);
+	Deno.exit(1);
+}


### PR DESCRIPTION
## Summary
- add Deno snapshot coverage for stable dotfiles CLI outputs
- expand native config tests and add a small line-coverage threshold checker
- run CLI tests through a 90% coverage threshold in CI

## Verification
- deno task --cwd cli check:all
- deno task --cwd cli test
- deno task --cwd cli coverage
- dprint check --config Configs/dprint/dprint.json --incremental=false