### PR TITLE
ci: make zizmor pedantic audit clean

### DIFF
--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -117,12 +117,12 @@ jobs:
           persist-credentials: false
 
       - name: 🔧 install nix
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🔧 set up nix cache
-        uses: DeterminateSystems/flakehub-cache-action@f9c8d8aaf92e6dbde896d6f84350f33d62392bd5 # main
+        uses: DeterminateSystems/flakehub-cache-action@4d48cd3cda2f381a3006ff800e1c1ca0c9809159 # v3.21.1
         with:
           token: ${{ secrets.FLAKEHUB_API_TOKEN }}
         continue-on-error: true
@@ -146,12 +146,12 @@ jobs:
           persist-credentials: false
 
       - name: 🔧 install nix
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🔧 set up nix cache
-        uses: DeterminateSystems/flakehub-cache-action@f9c8d8aaf92e6dbde896d6f84350f33d62392bd5 # main
+        uses: DeterminateSystems/flakehub-cache-action@4d48cd3cda2f381a3006ff800e1c1ca0c9809159 # v3.21.1
         with:
           token: ${{ secrets.FLAKEHUB_API_TOKEN }}
         continue-on-error: true
@@ -194,12 +194,12 @@ jobs:
           df -h /
 
       - name: 🔧 install nix
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🔧 set up nix cache
-        uses: DeterminateSystems/flakehub-cache-action@f9c8d8aaf92e6dbde896d6f84350f33d62392bd5 # main
+        uses: DeterminateSystems/flakehub-cache-action@4d48cd3cda2f381a3006ff800e1c1ca0c9809159 # v3.21.1
         with:
           token: ${{ secrets.FLAKEHUB_API_TOKEN }}
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
           persist-credentials: false
 
       - name: 🔧 install nix
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🔧 set up nix cache
-        uses: DeterminateSystems/flakehub-cache-action@f9c8d8aaf92e6dbde896d6f84350f33d62392bd5 # main
+        uses: DeterminateSystems/flakehub-cache-action@4d48cd3cda2f381a3006ff800e1c1ca0c9809159 # v3.21.1
         with:
           token: ${{ secrets.FLAKEHUB_API_TOKEN }}
         continue-on-error: true
@@ -119,12 +119,12 @@ jobs:
           persist-credentials: false
 
       - name: 🔧 install nix
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🔧 set up nix cache
-        uses: DeterminateSystems/flakehub-cache-action@f9c8d8aaf92e6dbde896d6f84350f33d62392bd5 # main
+        uses: DeterminateSystems/flakehub-cache-action@4d48cd3cda2f381a3006ff800e1c1ca0c9809159 # v3.21.1
         with:
           token: ${{ secrets.FLAKEHUB_API_TOKEN }}
         continue-on-error: true
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      security-events: write
+      security-events: write # Required to upload findings to GitHub Advanced Security (if enabled).
     steps:
       - name: 📥 checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/update-nix.yml
+++ b/.github/workflows/update-nix.yml
@@ -9,13 +9,17 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: update-nix-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update:
     name: update flake lock
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # Required to commit the updated flake.lock.
+      pull-requests: write # Required to open the automated pull request.
     steps:
       - name: 📥 checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -23,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: 🔧 install nix
-        uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Follow-up to #182 to address the remaining pedantic-level zizmor findings.

Changes:
- Pin DeterminateSystems actions to release tags (v22 / v3.21.1) instead of the main-branch HEAD, satisfying zizmor's stale-action-refs rule.
- Add inline comments explaining job-level write permissions, satisfying zizmor's undocumented-permissions rule.
- Add concurrency limits to the scheduled update-nix workflow, satisfying zizmor's concurrency-limits rule.

After this PR:
- No findings to report. Good job! (6 suppressed) reports: No findings to report. Good job!
- info[superfluous-actions]: action functionality is already included by the runner
  --> .github/workflows/update-nix.yml:69:15
   |
68 |       - name: 🤖 create pull request
   |         ---------------------------- this step
69 |         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use `gh pr create` in a script step
   |
   = note: audit confidence → Low
   = help: audit documentation → https://docs.zizmor.sh/audits/#superfluous-actions

6 findings (5 suppressed): 1 informational, 0 low, 0 medium, 0 high reports only one informational superfluous-actions suggestion about peter-evans/create-pull-request; this is a low-confidence code-smell finding and is not emitted in the default persona used by CI and [1;36m==>[0m [1mLocal CI Checks[0m

[34m==>[0m Checking formatting (dprint)....

Validation:
-  passed
-  passed with no findings