### PR TITLE
feat(codex): persist multi-agent limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,10 @@ jobs:
 
       - name: 🔍 shellcheck bash scripts
         run: |
-          shellcheck setup setup-tuckr-symlink.sh Hooks/nix/post.sh Hooks/nushell/post.sh Hooks/pnpm/post.sh \
-            Configs/shell/.config/shell/env.sh Configs/bash/.bashrc \
-            Configs/scripts/.local/bin/setup:dotfiles Configs/scripts/.local/bin/uninstall:dotfiles Configs/scripts/.local/bin/reset:dotfiles tests/setup-uninstall-reset-test.sh
+          shellcheck setup setup-tuckr-symlink.sh Hooks/nix/post.sh Hooks/nushell/post.sh Hooks/pnpm/post.sh Hooks/codex/post.sh \
+            Configs/codex/.config/codex/setup-codex.sh Configs/shell/.config/shell/env.sh Configs/bash/.bashrc \
+            Configs/scripts/.local/bin/setup:dotfiles Configs/scripts/.local/bin/uninstall:dotfiles Configs/scripts/.local/bin/reset:dotfiles \
+            tests/codex-setup-test.sh tests/setup-uninstall-reset-test.sh
 
       - name: 🔍 validate nushell scripts (nu-check)
         run: |
@@ -138,6 +139,7 @@ jobs:
 
       - name: 🧪 run test suite
         run: |
+          tests/codex-setup-test.sh
           nu Configs/scripts/.local/bin/test_scripts
 
       - name: ✅ verify generate-machine-config (cross-platform)

--- a/Configs/codex.group.toml
+++ b/Configs/codex.group.toml
@@ -1,0 +1,2 @@
+description = "Codex profiles and idempotent global multi-agent limits."
+presets = ["dev", "workstation"]

--- a/Configs/codex/.config/codex/providers.toml
+++ b/Configs/codex/.config/codex/providers.toml
@@ -11,7 +11,8 @@
 #   codex --profile ollama-deepseek # Local DeepSeek R1
 #   codex --profile cloud-kimi      # Kimi K2.5 via Ollama Cloud
 #
-# API keys are loaded from ~/.codex/secrets.env (not tracked in git)
+# API keys are normally injected from 1Password with `ssr codex`.
+# ~/.codex/secrets.env remains an optional untracked fallback.
 
 # ============================================================================
 # Custom Providers

--- a/Configs/codex/.config/codex/setup-codex.sh
+++ b/Configs/codex/.config/codex/setup-codex.sh
@@ -1,48 +1,174 @@
-#!/bin/bash
-# Setup script for Codex custom providers (Xiaomi MiMo, Ollama Cloud)
-# Ollama is built-in to Codex and does not need a custom provider.
-set -e
+#!/usr/bin/env bash
+# Setup script for Codex global settings and custom providers.
+# Ollama is built in to Codex and does not need a custom provider.
+set -euo pipefail
 
 CODEX_DIR="$HOME/.codex"
-DOTFILES_CODEX_DIR="$HOME/.config/codex"
+DOTFILES_CODEX_DIR="${DOTFILES_CODEX_DIR:-$HOME/.config/codex}"
 CONFIG="$CODEX_DIR/config.toml"
+TEMP_CONFIG=""
 
-echo "Setting up Codex custom providers..."
+cleanup() {
+	if [ -n "$TEMP_CONFIG" ]; then
+		rm -f "$TEMP_CONFIG"
+	fi
+}
+trap cleanup EXIT
+
+ensure_agent_limits() {
+	TEMP_CONFIG="$(mktemp "${TMPDIR:-/tmp}/codex-config.XXXXXX")"
+
+	awk '
+		function print_limit(key, value, line, indent, comment) {
+			indent = line
+			sub(/[^[:space:]].*$/, "", indent)
+			comment = line
+			sub(/^[^#]*/, "", comment)
+			print indent key " = " value (comment == "" ? "" : " " comment)
+		}
+
+		function add_missing_table_limits() {
+			if (!found_threads) {
+				print "max_threads = 32"
+				found_threads = 1
+			}
+			if (!found_depth) {
+				print "max_depth = 2"
+				found_depth = 1
+			}
+		}
+
+		function add_missing_dotted_limits() {
+			if (!found_threads) {
+				print "agents.max_threads = 32"
+				found_threads = 1
+			}
+			if (!found_depth) {
+				print "agents.max_depth = 2"
+				found_depth = 1
+			}
+		}
+
+		BEGIN {
+			in_root = 1
+		}
+
+		{
+			if (in_root && $0 ~ /^[[:space:]]*(agents|"agents"|\047agents\047)[[:space:]]*=/) {
+				print "Cannot safely update inline Codex agents configuration: " $0 > "/dev/stderr"
+				unsupported = 1
+				exit 2
+			}
+
+			if (in_root && $0 ~ /^[[:space:]]*(agents|"agents"|\047agents\047)[[:space:]]*\.[[:space:]]*(max_threads|"max_threads"|\047max_threads\047)[[:space:]]*=/) {
+				print_limit("agents.max_threads", 32, $0)
+				found_agents = 1
+				found_dotted_agents = 1
+				found_threads = 1
+				next
+			}
+
+			if (in_root && $0 ~ /^[[:space:]]*(agents|"agents"|\047agents\047)[[:space:]]*\.[[:space:]]*(max_depth|"max_depth"|\047max_depth\047)[[:space:]]*=/) {
+				print_limit("agents.max_depth", 2, $0)
+				found_agents = 1
+				found_dotted_agents = 1
+				found_depth = 1
+				next
+			}
+
+			if ($0 ~ /^[[:space:]]*\[[[:space:]]*(agents|"agents"|\047agents\047)[[:space:]]*\][[:space:]]*(#.*)?$/) {
+				if (in_root && found_dotted_agents) {
+					add_missing_dotted_limits()
+				}
+				in_root = 0
+				in_agents = 1
+				found_agents = 1
+				print
+				next
+			}
+
+			if ($0 ~ /^[[:space:]]*\[/) {
+				if (in_agents) {
+					add_missing_table_limits()
+					in_agents = 0
+				}
+				if (in_root) {
+					if (found_dotted_agents) {
+						add_missing_dotted_limits()
+					}
+					in_root = 0
+				}
+			}
+
+			if (in_agents && $0 ~ /^[[:space:]]*(max_threads|"max_threads"|\047max_threads\047)[[:space:]]*=/) {
+				print_limit("max_threads", 32, $0)
+				found_threads = 1
+				next
+			}
+
+			if (in_agents && $0 ~ /^[[:space:]]*(max_depth|"max_depth"|\047max_depth\047)[[:space:]]*=/) {
+				print_limit("max_depth", 2, $0)
+				found_depth = 1
+				next
+			}
+
+			print
+		}
+
+		END {
+			if (unsupported) {
+				exit 2
+			}
+			if (in_agents) {
+				add_missing_table_limits()
+			} else if (in_root && found_dotted_agents) {
+				add_missing_dotted_limits()
+			} else if (!found_agents) {
+				if (NR > 0) {
+					print ""
+				}
+				print "[agents]"
+				print "max_threads = 32"
+				print "max_depth = 2"
+			}
+		}
+	' "$CONFIG" >"$TEMP_CONFIG"
+
+	# Write through an existing symlink and preserve app-managed file metadata.
+	cat "$TEMP_CONFIG" >"$CONFIG"
+	rm -f "$TEMP_CONFIG"
+	TEMP_CONFIG=""
+	echo "✓ Ensured Codex multi-agent limits (max_threads = 32, max_depth = 2)"
+}
+
+echo "Setting up Codex configuration..."
 
 mkdir -p "$CODEX_DIR"
-
-# Check if secrets.env exists
-if [ ! -f "$CODEX_DIR/secrets.env" ]; then
-	echo ""
-	echo "⚠  secrets.env not found in $CODEX_DIR"
-	echo "   Create it with your API keys:"
-	echo ""
-	echo "   cat > $CODEX_DIR/secrets.env << 'EOF'"
-	echo "   XIAOMI_MIMO_API_KEY=tp-your-key-here"
-	echo "   OLLAMA_CLOUD_API_KEY=your-ollama-cloud-key"
-	echo "   EOF"
-	echo "   chmod 600 $CODEX_DIR/secrets.env"
-	echo ""
-else
-	echo "✓ secrets.env exists"
+if [ ! -e "$CONFIG" ]; then
+	(umask 077 && touch "$CONFIG")
 fi
 
-# Add providers to config.toml if not already present
-if [ -f "$CONFIG" ]; then
-	if ! grep -q "\[model_providers.xiaomi\]" "$CONFIG"; then
-		echo "Adding custom providers to config.toml..."
-		if [ -f "$DOTFILES_CODEX_DIR/providers.toml" ]; then
-			echo "" >>"$CONFIG"
-			cat "$DOTFILES_CODEX_DIR/providers.toml" >>"$CONFIG"
-			echo "✓ Added custom providers"
-		else
-			echo "⚠ providers.toml not found in dotfiles"
-		fi
+ensure_agent_limits
+
+# Check whether the optional plaintext fallback exists. Monosecret is preferred.
+if [ ! -f "$CODEX_DIR/secrets.env" ]; then
+	echo "ℹ  Optional $CODEX_DIR/secrets.env fallback not found; use 'ssr codex' for 1Password-backed keys"
+else
+	echo "✓ secrets.env fallback exists"
+fi
+
+# Add providers to config.toml if not already present.
+if ! grep -q "\[model_providers.xiaomi\]" "$CONFIG"; then
+	echo "Adding custom providers to config.toml..."
+	if [ -f "$DOTFILES_CODEX_DIR/providers.toml" ]; then
+		printf '\n' >>"$CONFIG"
+		cat "$DOTFILES_CODEX_DIR/providers.toml" >>"$CONFIG"
+		echo "✓ Added custom providers"
 	else
-		echo "✓ Custom providers already configured"
+		echo "⚠ providers.toml not found in dotfiles"
 	fi
 else
-	echo "⚠ config.toml not found — run 'codex' once to create it, then re-run this script"
+	echo "✓ Custom providers already configured"
 fi
 
 echo ""

--- a/Hooks/codex/post.sh
+++ b/Hooks/codex/post.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SETUP_SCRIPT="$HOME/.config/codex/setup-codex.sh"
+
+if [ ! -f "$SETUP_SCRIPT" ]; then
+	echo "Codex setup script not found: $SETUP_SCRIPT" >&2
+	exit 1
+fi
+
+bash "$SETUP_SCRIPT"

--- a/docs/agents/repository-architecture.md
+++ b/docs/agents/repository-architecture.md
@@ -28,6 +28,7 @@
 
 ## Active Hooks
 
+- `Hooks/codex/post.sh`: merge managed multi-agent limits and provider profiles into the app-managed Codex config.
 - `Hooks/nix/post.sh`: rebuild system config after Nix deployment.
 - `Hooks/nushell/post.sh`: generate vendor autoload and configure shell behavior.
 - `Hooks/pnpm/post.sh`: sync managed pnpm global manifests and install global packages.

--- a/docs/codex-setup.md
+++ b/docs/codex-setup.md
@@ -1,12 +1,28 @@
-# Codex Custom Providers Setup
+# Codex Setup
 
-Codex supports Xiaomi MiMo, local Ollama, and Ollama Cloud models via custom providers.
+The `codex` dotfiles group manages global multi-agent limits and custom provider profiles for Xiaomi MiMo, local Ollama, and Ollama Cloud.
 
 ## Quick Setup
 
-```bash
-~/.config/codex/setup-codex.sh
+The `dev` and `workstation` setup presets deploy the group and run its idempotent post-install hook automatically. To apply it manually or refresh an existing installation:
+
+```nu
+^tuckr set codex
 ```
+
+The hook runs `~/.config/codex/setup-codex.sh`. It creates `~/.codex/config.toml` when needed and updates only the settings managed here, preserving unrelated Codex app and CLI content.
+
+## Global Multi-Agent Limits
+
+Fresh and existing configurations receive:
+
+```toml
+[agents]
+max_threads = 32
+max_depth = 2
+```
+
+Re-running setup updates these two values without duplicating the table or provider template.
 
 ## Available Profiles
 
@@ -23,21 +39,21 @@ Codex supports Xiaomi MiMo, local Ollama, and Ollama Cloud models via custom pro
 
 ## Usage
 
-```bash
-codex --profile mimo              # Xiaomi MiMo-V2.5-Pro
-codex --profile ollama-gemma4     # Local Gemma4 26B
-codex --profile cloud-kimi        # Kimi K2.5 via cloud
+```nu
+^codex --profile mimo              # Xiaomi MiMo-V2.5-Pro
+^codex --profile ollama-gemma4     # Local Gemma4 26B
+^codex --profile cloud-kimi        # Kimi K2.5 via cloud
 ```
 
 ## Secrets
 
 API keys are managed via **Monosecret + 1Password** (not plaintext on disk).
 
-```bash
+```nu
 # Run Codex with secrets injected from 1Password:
 ssr codex --profile mimo
 
-# Or load all secrets into shell first:
+# Or load all secrets into the current shell first:
 ssload
 ```
 
@@ -58,4 +74,5 @@ A fallback `~/.codex/secrets.env` (mode 600, not in git) can be used when 1Passw
 
 - Ollama is a **built-in** Codex provider — no custom definition needed
 - Use `--local-provider ollama` or `--oss` for local models without a profile
-- Xiaomi MiMo and Ollama Cloud are custom providers defined in config.toml
+- Xiaomi MiMo and Ollama Cloud are custom providers appended to `~/.codex/config.toml` once
+- The setup hook preserves unrelated app-managed configuration and is safe to run repeatedly

--- a/tests/codex-setup-test.sh
+++ b/tests/codex-setup-test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SETUP_SCRIPT="$ROOT_DIR/Configs/codex/.config/codex/setup-codex.sh"
+PROVIDERS_DIR="$ROOT_DIR/Configs/codex/.config/codex"
+HOOK_SCRIPT="$ROOT_DIR/Hooks/codex/post.sh"
+GROUP_METADATA="$ROOT_DIR/Configs/codex.group.toml"
+TEST_DIR="$(mktemp -d)"
+TEST_HOME="$TEST_DIR/home"
+CONFIG="$TEST_HOME/.codex/config.toml"
+
+cleanup() {
+	rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+	echo "codex setup test failed: $1" >&2
+	exit 1
+}
+
+require_line() {
+	local line="$1"
+	grep -Fqx -- "$line" "$CONFIG" || fail "missing line: $line"
+}
+
+require_count() {
+	local expected="$1"
+	local pattern="$2"
+	local actual
+
+	actual="$(grep -Ec "$pattern" "$CONFIG" || true)"
+	[ "$actual" -eq "$expected" ] || fail "expected $expected matches for $pattern, found $actual"
+}
+
+run_setup() {
+	HOME="$TEST_HOME" DOTFILES_CODEX_DIR="$PROVIDERS_DIR" bash "$SETUP_SCRIPT" >/dev/null
+}
+
+validate_toml() {
+	local config_path="${1:-$CONFIG}"
+
+	# Nushell reads CONFIG_PATH at runtime; Bash must not expand the command body.
+	# shellcheck disable=SC2016
+	CONFIG_PATH="$config_path" nu -c '
+		let config = (open --raw $env.CONFIG_PATH | from toml)
+		if $config.agents.max_threads != 32 {
+			error make { msg: "agents.max_threads was not set to 32" }
+		}
+		if $config.agents.max_depth != 2 {
+			error make { msg: "agents.max_depth was not set to 2" }
+		}
+	' || fail "generated config is not valid TOML with the expected limits"
+}
+
+mkdir -p "$TEST_HOME"
+
+# A fresh installation creates config.toml with both managed settings and providers.
+run_setup
+[ -f "$CONFIG" ] || fail "fresh setup did not create config.toml"
+validate_toml
+require_count 1 '^\[agents\]$'
+require_count 1 '^max_threads[[:space:]]*='
+require_count 1 '^max_depth[[:space:]]*='
+require_count 1 '^\[model_providers\.xiaomi\]$'
+
+# Existing app-managed settings, sections, and comments are preserved while the
+# two managed values are updated.
+cat >"$CONFIG" <<'EOF'
+model = "app-managed-model"
+# Keep this app-managed comment.
+
+[agents]
+max_threads = 4 # retain this explanation
+custom_setting = "keep-me"
+max_depth = 9
+
+[projects."/tmp/example"]
+trust_level = "trusted"
+EOF
+
+run_setup
+validate_toml
+require_line 'model = "app-managed-model"'
+require_line '# Keep this app-managed comment.'
+require_line 'max_threads = 32 # retain this explanation'
+require_line 'custom_setting = "keep-me"'
+require_line 'trust_level = "trusted"'
+require_count 1 '^\[agents\]$'
+require_count 1 '^max_threads[[:space:]]*='
+require_count 1 '^max_depth[[:space:]]*='
+require_count 1 '^\[model_providers\.xiaomi\]$'
+
+# A second run produces no further config changes.
+cp "$CONFIG" "$TEST_DIR/config.once.toml"
+run_setup
+cmp -s "$TEST_DIR/config.once.toml" "$CONFIG" || fail "setup is not idempotent"
+
+# Quoted table/key syntax and root-level dotted keys remain valid TOML.
+cat >"$CONFIG" <<'EOF'
+["agents"]
+"max_threads" = 3
+'max_depth' = 7
+other = true
+EOF
+run_setup
+validate_toml
+require_line '["agents"]'
+require_line 'other = true'
+
+cat >"$CONFIG" <<'EOF'
+agents."max_threads" = 3 # keep dotted style valid
+model = "app-managed-model"
+
+[features]
+multi_agent = true
+EOF
+run_setup
+validate_toml
+require_line 'agents.max_threads = 32 # keep dotted style valid'
+require_line 'agents.max_depth = 2'
+require_line 'multi_agent = true'
+
+# An unsupported inline table fails safely instead of creating duplicate TOML keys.
+cat >"$CONFIG" <<'EOF'
+model = "leave-this-file-alone"
+agents = { max_threads = 3, max_depth = 1 }
+EOF
+cp "$CONFIG" "$TEST_DIR/inline-agents.toml"
+if HOME="$TEST_HOME" DOTFILES_CODEX_DIR="$PROVIDERS_DIR" bash "$SETUP_SCRIPT" >/dev/null 2>&1; then
+	fail "inline agents configuration should require manual normalization"
+fi
+cmp -s "$TEST_DIR/inline-agents.toml" "$CONFIG" || fail "failed inline update changed config.toml"
+
+# Updating a symlinked config writes through it instead of replacing the link.
+SYMLINK_TARGET="$TEST_DIR/symlinked-config.toml"
+printf 'model = "symlink-managed"\n' >"$SYMLINK_TARGET"
+rm -f "$CONFIG"
+ln -s "$SYMLINK_TARGET" "$CONFIG"
+run_setup
+[ -L "$CONFIG" ] || fail "setup replaced a symlinked config.toml"
+validate_toml "$SYMLINK_TARGET"
+grep -Fqx 'model = "symlink-managed"' "$SYMLINK_TARGET" || fail "symlink target content was not preserved"
+
+# The deployed hook resolves the setup script from ~/.config/codex.
+HOOK_HOME="$TEST_DIR/hook-home"
+mkdir -p "$HOOK_HOME/.config"
+ln -s "$PROVIDERS_DIR" "$HOOK_HOME/.config/codex"
+HOME="$HOOK_HOME" bash "$HOOK_SCRIPT" >/dev/null
+validate_toml "$HOOK_HOME/.codex/config.toml"
+
+# Group metadata keeps Codex setup in both user-facing developer presets.
+# Nushell reads GROUP_METADATA at runtime; Bash must not expand the command body.
+# shellcheck disable=SC2016
+GROUP_METADATA="$GROUP_METADATA" nu -c '
+	let metadata = (open --raw $env.GROUP_METADATA | from toml)
+	if "dev" not-in $metadata.presets or "workstation" not-in $metadata.presets {
+		error make { msg: "codex group is missing a required setup preset" }
+	}
+' || fail "Codex group metadata does not cover fresh developer installations"
+
+echo "codex setup test passed"


### PR DESCRIPTION
Persist Codex multi-agent limits at 32 threads and depth 2 through an idempotent dotfiles setup hook. Adds isolated setup tests, CI coverage, and documentation while preserving unrelated app-managed Codex configuration.