### PR TITLE
feat(agents): add global agent instructions and PR skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This repository is a cross-platform, Tuckr-managed dotfiles repository that depl
 
 - Package manager/runtime: `nix` (use `nix profile add`; avoid `nix profile install`).
 - Shared/global agent skills that should survive across machines belong in `Configs/agents/.agents/skills/<skill-name>` and are deployed to `~/.agents/skills/<skill-name>` by the `agents` Tuckr group. Do not leave reusable skills only in the local `~/.agents/skills` directory.
+- The global agent instructions file lives at `Configs/agents/.config/agents/AGENTS.md` and is symlinked to every harness's global location (`~/.pi/agent/AGENTS.md`, `~/.codex/AGENTS.md`, `~/.config/zed/AGENTS.md`, `~/.config/opencode/AGENTS.md`). Edit the canonical file only, never the symlinks.
 - Non-standard verification commands:
   - `dprint check --config Configs/dprint/dprint.json`
   - `shellcheck setup setup-tuckr-symlink.sh Hooks/*/post.sh`

--- a/Configs/agents.group.toml
+++ b/Configs/agents.group.toml
@@ -1,3 +1,3 @@
-description = "AI agent configurations and shared skills/extensions. Manages ~/.config/agents/, ~/.config/opencode/, and ~/.agents/ (skills, extensions)."
+description = "AI agent configurations and shared skills/extensions. Manages ~/.config/agents/, ~/.config/opencode/, ~/.agents/ (skills, extensions), and the global AGENTS.md symlinked across pi, codex, zed, and opencode."
 depends_on = ["pnpm"]
 presets = ["dev", "workstation"]

--- a/Configs/agents/.agents/skills/babysit-pr/SKILL.md
+++ b/Configs/agents/.agents/skills/babysit-pr/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: babysit-pr
+description: Monitor and maintain an open pull request until it merges. Use whenever the user asks to monitor,
+  watch, or babysit a PR, or wants a PR kept up to date, review feedback handled, CI failures fixed, or scope
+  creep stopped.
+---
+
+# Babysit Pull Request
+
+Keep an open PR healthy and mergeable until it's merged or the user says stop: rebase on main, handle review feedback, fix CI, and hold the line on scope.
+
+## The loop
+
+Run this as a recurring check (cadence set by the caller) until the PR is merged, closed, or the user ends the session. Each cycle:
+
+1. Rebase the branch on main
+2. Check CI status
+3. Read new review feedback
+4. Push fixes and replies
+5. Report status to the user, including the full PR URL
+
+## 1. Rebase on main
+
+- `git fetch origin main` then rebase the PR branch on it
+- Only rebase when main has actually advanced — don't churn
+- Resolve conflicts with minimal changes that preserve intent from both sides
+- After rebasing, force-push with `--force-with-lease` (safe under squash-merge workflows)
+
+## 2. Address review feedback
+
+- Read every new comment: AI/bot reviews (e.g. CodeRabbit), human reviewers, and inline threads
+- Valid feedback — make the change, commit, and push
+- False positives — never silently ignore; reply on the thread with a clear rationale for why the comment does not apply
+
+## 3. Fix CI failures
+
+- Check CI status after every push (`gh pr checks`)
+- Fix failures promptly — red CI blocks review and merge
+- If a failing check is flaky or broken and unrelated to the PR, state that in the report instead of hacking around it
+
+## 4. Stop scope creep
+
+- The PR's purpose is fixed; do not add features, refactors, or unrelated fixes to it
+- New work surfaced during babysitting (bugs, ideas) goes to a new issue or PR — note it in the report
+- Push back on anything that would balloon the PR and suggest a follow-up instead
+
+## Reporting
+
+After each cycle, give a concise status update: what was rebased, fixed, or answered; current CI state; what's blocking; and always the full PR URL (`gh pr view --json url --jq .url`).
+
+End every status update and PR comment with the attribution footer:
+
+```
+_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by <harness> using <model> at <thinking level> thinking._
+```
+
+Fill in your real details — the harness (e.g. pi, codex), the model you are running (e.g. GPT-5.5, Claude, DeepSeek), and your thinking level. Do not guess; use what you know about your own configuration.
+
+## Done
+
+When the PR merges: report it, clean up (e.g. remove the worktree per the git-workflow skill), and stop. When the user says stop: stop.

--- a/Configs/agents/.agents/skills/babysit-pr/SKILL.md
+++ b/Configs/agents/.agents/skills/babysit-pr/SKILL.md
@@ -7,24 +7,29 @@ description: Monitor and maintain an open pull request until it merges. Use when
 
 # Babysit Pull Request
 
-Keep an open PR healthy and mergeable until it's merged or the user says stop: rebase on main, handle review feedback, fix CI, and hold the line on scope.
+Keep an open PR healthy and mergeable until it's merged or the user says stop: resolve conflicts with main, handle review feedback, fix CI, and hold the line on scope.
 
 ## The loop
 
 Run this as a recurring check (cadence set by the caller) until the PR is merged, closed, or the user ends the session. Each cycle:
 
-1. Rebase the branch on main
+1. Check for conflicts with main and resolve them (rebase, or merge for merge-based branches)
 2. Check CI status
 3. Read new review feedback
 4. Push fixes and replies
 5. Report status to the user, including the full PR URL
 
-## 1. Rebase on main
+## 1. Check for conflicts and rebase on main
 
-- `git fetch origin main` then rebase the PR branch on it
-- Only rebase when main has actually advanced — don't churn
-- Resolve conflicts with minimal changes that preserve intent from both sides
-- After rebasing, force-push with `--force-with-lease` (safe under squash-merge workflows)
+- **Always check whether the PR has conflicts with `origin/main`** — resolving conflicts is a core part of babysitting, not an afterthought
+- Check mergeability: `gh pr view --json mergeable,mergeStateStatus --jq '{mergeable, mergeStateStatus}'` (or `git fetch origin main` and compare against the branch)
+- If the PR has conflicts with `origin/main`, resolve them by rebasing the branch on top of `origin/main`:
+  - `git fetch origin main` then `git rebase origin/main`
+  - Resolve conflicts with minimal changes that preserve intent from both sides
+  - After rebasing, force-push with `--force-with-lease` (safe under squash-merge workflows)
+- **Caveat — merge-based branches:** if the branch is based on merging (its history contains merge commits, e.g. `git log --oneline --merges origin/main..HEAD` returns anything), rebasing is unrealistic. In that case, merge `origin/main` into the branch instead (`git merge origin/main`) and push normally.
+- Default is rebase; only fall back to merging when the branch is genuinely merge-based
+- Only rebase when main has actually advanced or conflicts exist — don't churn
 
 ## 2. Address review feedback
 
@@ -46,7 +51,7 @@ Run this as a recurring check (cadence set by the caller) until the PR is merged
 
 ## Reporting
 
-After each cycle, give a concise status update: what was rebased, fixed, or answered; current CI state; what's blocking; and always the full PR URL (`gh pr view --json url --jq .url`).
+After each cycle, give a concise status update: what was rebased/merged, conflicts resolved, fixed, or answered; current CI state; what's blocking; and always the full PR URL (`gh pr view --json url --jq .url`).
 
 End every status update and PR comment with the attribution footer:
 

--- a/Configs/agents/.agents/skills/create-pr/SKILL.md
+++ b/Configs/agents/.agents/skills/create-pr/SKILL.md
@@ -49,12 +49,9 @@ Briefly describe how the PR solves it:
 - Key areas or files changed
 - Notable trade-offs or follow-ups
 
-### 3. Validation — only what's specific to this PR
+### 3. No Testing or Validation section
 
-Standard checks are assumed — if the PR passes CI, that's good enough. Don't pad the description with generic validation:
-
-- Don't list routine checks like linting, formatting, or the build — every PR runs those
-- Only mention validation specific to this PR: e.g. "the full test suite was run and passes" when tests were updated, or profiling, benchmarks, or manual verification you performed
+Never include `## Testing` or `## Validation` sections — for projects with CI and workflows set up, it's redundant. The validation happens in CI; it doesn't need to be repeated in the description. Unless the user explicitly asks you to specify what was tested and how you validated the code, don't include it — just explain what you did in Implementation.
 
 ## Attribution footer
 
@@ -73,6 +70,6 @@ Fill in your real details — the harness (e.g. pi, codex), the model you are ru
 - [ ] Title is a concise, human-readable conventional commit message (with `!` for breaking changes)
 - [ ] Description opens with the reason the PR was created — a problem, not an inventory of changes
 - [ ] Implementation details come after the why
-- [ ] Validation mentions only PR-specific checks; CI passing covers the rest
+- [ ] No Testing/Validation section (CI covers it) unless the user explicitly asked
 - [ ] Attribution footer: on behalf of Ifiok Jr. (@ifiokjr), harness, model, thinking level
 - [ ] No generic filler like "This PR fixes stuff"

--- a/Configs/agents/.agents/skills/create-pr/SKILL.md
+++ b/Configs/agents/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: create-pr
+description: Create full pull requests with concise, human-readable conventional-commit titles and problem-first
+  descriptions. Use whenever the user asks to file, open, or create a pull request, wants a pull request made
+  for their work, or when completed work is ready for a pull request.
+---
+
+# Create Pull Request
+
+Open **full** pull requests (never drafts) that are ready to merge: a concise, human-readable title that doubles as the squash-commit message, and a problem-first description instead of a raw inventory of changes.
+
+## Before creating
+
+Match the repository's conventions:
+
+- Check for a PR template (e.g. `.github/PULL_REQUEST_TEMPLATE.md`) and follow it
+- Follow the repo's workflow: target branch, labels, commit conventions
+- Create a **full PR — never a draft** unless the user explicitly asks for a draft
+
+## PR Title
+
+The PR title becomes the commit message when the PR is squash-merged, so write it as a concise conventional commit message:
+
+- **Type** — `fix:`, `docs:`, `feat:`, `refactor:`, `test:`, `ci:`, `build:`, `chore:`
+- **Breaking change** — add `!` after the type (and scope if present): `fix(api)!:`, `feat!:`
+- **Scope** — add when it adds clarity: `fix(solana): ...`
+- One line, imperative mood, describing what the PR does
+- Match the branch's intent (a `feat/` branch gets a `feat:` title)
+
+## PR Description
+
+Lead with **why**, then **how**. Keep it concise and specific — no filler.
+
+### 1. Why — the reason this PR exists (always first)
+
+Describe the problem that prompted the PR — the reason it exists — not a raw inventory of what changed:
+
+- What problem was the user facing, or what did they ask for?
+- Capture any discussion that led to the PR — the context and decisions from the conversation, using the user's own framing where possible
+- If the reason is not clear from the conversation, ask the user rather than inventing one
+
+Example: "The settings screen took several seconds to render on device, making the app feel unresponsive. This PR was created to fix that slowness."
+
+### 2. Implementation — how it solves the problem (after Why)
+
+Briefly describe how the PR solves it:
+
+- Approach taken and why
+- Key areas or files changed
+- Notable trade-offs or follow-ups
+
+### 3. Validation — only what's specific to this PR
+
+Standard checks are assumed — if the PR passes CI, that's good enough. Don't pad the description with generic validation:
+
+- Don't list routine checks like linting, formatting, or the build — every PR runs those
+- Only mention validation specific to this PR: e.g. "the full test suite was run and passes" when tests were updated, or profiling, benchmarks, or manual verification you performed
+
+## Attribution footer
+
+End every PR description with who created it and how:
+
+```
+_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by <harness> using <model> at <thinking level> thinking._
+```
+
+Fill in your real details — the harness (e.g. pi, codex), the model you are running (e.g. GPT-5.5, Claude, DeepSeek), and your thinking level. Do not guess; use what you know about your own configuration.
+
+## Checklist
+
+- [ ] Created as a **full PR, not a draft** (unless explicitly asked)
+- [ ] Followed the repository's PR template and conventions
+- [ ] Title is a concise, human-readable conventional commit message (with `!` for breaking changes)
+- [ ] Description opens with the reason the PR was created — a problem, not an inventory of changes
+- [ ] Implementation details come after the why
+- [ ] Validation mentions only PR-specific checks; CI passing covers the rest
+- [ ] Attribution footer: on behalf of Ifiok Jr. (@ifiokjr), harness, model, thinking level
+- [ ] No generic filler like "This PR fixes stuff"

--- a/Configs/agents/.codex/AGENTS.md
+++ b/Configs/agents/.codex/AGENTS.md
@@ -1,0 +1,1 @@
+../.config/agents/AGENTS.md

--- a/Configs/agents/.config/agents/AGENTS.md
+++ b/Configs/agents/.config/agents/AGENTS.md
@@ -1,0 +1,31 @@
+# Global agent instructions
+
+## Who I am
+
+Hi, I'm Ifiok — `ifiokjr` on GitHub and everywhere else. You are my agent. Your name is Uche.
+
+## What I want from you
+
+I'm a builder. My work is coding and building projects, and I want your help making things that are:
+
+- **Simple** — the smallest thing that works, not the biggest thing that could.
+- **Fun and engaging** — I build things people enjoy coming back to.
+- **Well-designed** — craft and polish matter as much as the code.
+- **Different** — I'm not interested in clones of what already exists. I like little twists on familiar things.
+
+The things I want to put into the world are **visual** and make people do things in ways they don't normally do. A game of mine shouldn't just be played — it should be played _differently_. I once built a game you play by rotating your phone, so it was obvious you were doing something new. These ideas won't always succeed, and I haven't shipped anything yet to know if they do, but they should be different, dynamic, visual, and engaging.
+
+If an idea feels generic, say so — that's part of the job. Push back when something is over-engineered or derivative; simple usually wins.
+
+## How I build
+
+- **Flutter** for apps.
+- **Rust** for the big stuff — builders, tooling, performance-critical code.
+- **Solana** is my blockchain of choice — most projects will integrate it in some way.
+- Write **idiomatic code** for the environment we're working in. Don't transplant patterns between languages.
+- In **TypeScript**, never use `any`. Types stay strict and explicit.
+
+## House rules
+
+- Branch names use conventional commit prefixes: `feat/`, `fix/`, `test/`, `ci/`, `build/`, `chore/`, `refactor/`.
+- Whenever commenting on a GitHub issue or creating a pull request, add an attribution: created on behalf of Ifiok Jr. (`@ifiokjr`), including the model used and the thinking level it was generated at.

--- a/Configs/agents/.config/agents/README.md
+++ b/Configs/agents/.config/agents/README.md
@@ -9,6 +9,7 @@ This directory centralizes configuration for all AI coding agents and tools.
 | **OpenCode** | `~/.config/opencode/` | Universal AI agent with multi-model support |
 | **Pi**       | `~/.pi/agent/`        | AI-powered development environment          |
 | **Codex**    | `~/.codex/`           | OpenAI's Codex CLI tool                     |
+| **Zed**      | `~/.config/zed/`      | AI-powered code editor with agent panel     |
 
 ## Configuration Files
 
@@ -28,6 +29,19 @@ OpenCode-specific configuration:
 - Trusted directory list
 - Default model/provider settings
 - UI confirmation preferences
+
+### `AGENTS.md`
+
+The canonical global agent instructions file. Every harness's global instruction file is a symlink to this file, so one edit updates all of them:
+
+| Harness      | Global Instructions Location   |
+| ------------ | ------------------------------ |
+| **Pi**       | `~/.pi/agent/AGENTS.md`        |
+| **Codex**    | `~/.codex/AGENTS.md`           |
+| **Zed**      | `~/.config/zed/AGENTS.md`      |
+| **OpenCode** | `~/.config/opencode/AGENTS.md` |
+
+Edit the canonical file only — the harness locations are symlinks to it.
 
 ## Security Considerations
 
@@ -76,8 +90,9 @@ When adding a new AI tool:
 1. Create its config directory under `.config/<tool>/`
 2. Add any environment variables to `agents.env.sh`
 3. For OpenCode plugins, add installation to `Hooks/agents/post.sh`
-4. Document the tool in this README
-5. Update the table above
+4. To give it the global agent instructions, add a symlink at `Configs/agents/<harness-path>/<file>` pointing to `../.config/agents/AGENTS.md` (relative), using the harness's global file name and location
+5. Document the tool in this README
+6. Update the table above
 
 ## Related
 

--- a/Configs/agents/.config/opencode/AGENTS.md
+++ b/Configs/agents/.config/opencode/AGENTS.md
@@ -1,0 +1,1 @@
+../../.config/agents/AGENTS.md

--- a/Configs/agents/.config/zed/AGENTS.md
+++ b/Configs/agents/.config/zed/AGENTS.md
@@ -1,0 +1,1 @@
+../../.config/agents/AGENTS.md

--- a/Configs/agents/.pi/agent/AGENTS.md
+++ b/Configs/agents/.pi/agent/AGENTS.md
@@ -1,0 +1,1 @@
+../../.config/agents/AGENTS.md

--- a/cli/test/__snapshots__/cli_snapshot_test.ts.snap
+++ b/cli/test/__snapshots__/cli_snapshot_test.ts.snap
@@ -193,7 +193,7 @@ Nix:      <nix>
 snapshot[`safe command outputs are stable > groups list 1`] = `
 "
 ==> Available configuration groups
-  agents         AI agent configurations and shared skills/extensions. Manages ~/.config/agents/, ~/.config/opencode/, and ~/.agents/ (skills, extensions).
+  agents         AI agent configurations and shared skills/extensions. Manages ~/.config/agents/, ~/.config/opencode/, ~/.agents/ (skills, extensions), and the global AGENTS.md symlinked across pi, codex, zed, and opencode.
   atuin          Atuin shell history manager — session-first up-arrow, global Ctrl-R.
   bash           Bash shell configuration and interactive shell defaults.
   codex          codex


### PR DESCRIPTION
## Why

The global AGENTS.md only contained identity and branch-naming rules. Ifiok wanted it to capture who he is and what he wants from his agents — projects that are simple, fun, engaging, well-designed, and different, with visual and novel interactions — and how he builds: Flutter for apps, Rust for the heavy lifting, Solana as his blockchain, idiomatic code per environment, and no `any` in TypeScript. He also wanted the same instructions to apply across every harness he uses (pi, codex, zed, opencode) and any he tries in the future, plus skills that encode how pull requests should be created and maintained.

## Implementation

- **Canonical global instructions** at `Configs/agents/.config/agents/AGENTS.md`, symlinked to each harness's global location (`~/.pi/agent/AGENTS.md`, `~/.codex/AGENTS.md`, `~/.config/zed/AGENTS.md`, `~/.config/opencode/AGENTS.md`) via git symlinks deployed by the `agents` Tuckr group — one edit updates every harness
- **`create-pr` skill**: conventional-commit titles (with `!` for breaking changes), problem-first descriptions, validation limited to what's specific to the PR, and an attribution footer
- **`babysit-pr` skill**: rebase on main, address AI/bot review feedback (false positives get rationale replies, never silent ignores), fix CI failures, stop scope creep, and the same attribution footer
- README and group description updated; repo AGENTS.md documents the canonical-file pattern

## Validation

- `dprint check` passes for all files in this PR
- Symlink chains verified end-to-end on this machine (all four harness locations resolve to the canonical file)

---

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using deepseek-v4-flash:0731 at xhigh thinking._
