### PR TITLE
feat(agents): forbid worktrees inside git repositories

### DIFF
--- a/Configs/agents/.agents/skills/git-workflow/SKILL.md
+++ b/Configs/agents/.agents/skills/git-workflow/SKILL.md
@@ -45,6 +45,8 @@ git stash push -m "interrupted: switching to urgent bugfix PR #123"
 
 **Start new work in a fresh worktree rather than working directly on `main` or the current branch.**
 
+**Worktree should never be added as a subdirectory of a Git repository.** Always create worktrees outside the repo (e.g. a sibling `../worktrees/` directory), never inside it — a nested worktree pollutes the main checkout with untracked files and nested Git metadata.
+
 - Create a worktree for every distinct task or feature: `git worktree add -b feat/description ../worktrees/feat-description`
 - Keeps `main` clean and available for quick reference, hotfixes, or parallel reviews
 - Eliminates risk of accidentally committing work-in-progress to the trunk
@@ -113,6 +115,8 @@ git worktree list --porcelain
 ```
 
 **Prefer worktrees for all new work.** See [Core Principle #3: Use worktrees for new work](#3-use-worktrees-for-new-work).
+
+**Worktree should never be added as a subdirectory of a Git repository.** Worktrees live outside the repo (e.g. `../worktrees/<name>`), never inside it.
 
 If the oh-pi worktree extension is available, prefer:
 

--- a/Configs/agents/.config/agents/AGENTS.md
+++ b/Configs/agents/.config/agents/AGENTS.md
@@ -27,5 +27,6 @@ If an idea feels generic, say so — that's part of the job. Push back when some
 
 ## House rules
 
+- **Worktree should never be added as a subdirectory of a Git repository.** Always create worktrees outside the repository (e.g. a sibling `worktrees/` directory), never inside it.
 - Branch names use conventional commit prefixes: `feat/`, `fix/`, `test/`, `ci/`, `build/`, `chore/`, `refactor/`.
 - Whenever commenting on a GitHub issue or creating a pull request, add an attribution: created on behalf of Ifiok Jr. (`@ifiokjr`), including the model used and the thinking level it was generated at.


### PR DESCRIPTION
## Why

Worktrees created as a subdirectory of a Git repository are an anti-pattern — they pollute the main checkout with untracked files and nested Git metadata, and break tooling that assumes one checkout per repo. This should never happen, so it's now an explicit hard rule.

## Implementation

- **Global AGENTS.md** — new bolded house rule: "Worktree should never be added as a subdirectory of a Git repository." The canonical file at `Configs/agents/.config/agents/AGENTS.md` propagates to pi, codex, zed, and opencode via symlinks.
- **git-workflow skill** — same rule added to Core Principle #3 (Use worktrees for new work) and the Worktree-aware workflow section.

Verified with `dprint check`; no formatting issues.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using DeepSeek at high thinking level._