### PR TITLE
fix(nushell): remove `update` alias shadowing builtin; add surfpool to home packages

### DIFF
--- a/Configs/nix/.config/nix/home.nix
+++ b/Configs/nix/.config/nix/home.nix
@@ -178,6 +178,7 @@ in
       extra.pnpm-11
       extra.op # 1password
       extra.serverpod_cli
+      extra.surfpool
 
       # Fonts
       fontforge

--- a/Configs/nushell/.config/nushell/config.nu
+++ b/Configs/nushell/.config/nushell/config.nu
@@ -118,7 +118,9 @@ alias s = exec nu
 # Job control
 alias fg = job unfreeze
 # Nix
-alias update = nix flake update --flake $"($env.HOME)/.config/nix"
+# `update` intentionally NOT aliased: it shadows the built-in `update` command
+# and breaks third-party nu scripts (e.g. vite-plus env.nu) that call it.
+# Use `nfu` instead (see below).
 # Editors
 alias vim = nvim
 alias n = nvim


### PR DESCRIPTION
Every new shell failed to start with `nu::parser::variable_not_found` pointing at `~/.vite-plus/env.nu:40`. Root cause: `alias update = nix flake update --flake ...` in the nushell config shadows the built-in `update` command. Vite+'s env.nu calls `update value {|row| ...}`, and once `update` resolved to the alias, the closure's scope got mangled and the parser reported `$need_quote` as undefined. (Reproduced with `nu -l -i`; confirmed fixed by removing the alias.)

## Implementation

- **`Configs/nushell/.config/nushell/config.nu`** — removed `alias update` and left a comment explaining why. `alias nfu` already provides the identical `nix flake update --flake ~/.config/nix` shortcut, so nothing is lost.
- **`Configs/nix/.config/nix/home.nix`** — added `extra.surfpool` (v1.5.0, prebuilt from github.com/txtx/surfpool) to home.packages from the `ifiokjr-nixpkgs` flake input; already present at the locked flake revision, so no lock update was needed.

Verified: `nix flake check --impure --no-build` ✅, `nixfmt --check` ✅, `dprint check` ✅, and `nu -l -i` starts cleanly.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using deepseek-v4-flash:0731 at high thinking._