### PR TITLE
fix(opencode): use string model field instead of invalid object

### DIFF
--- a/Configs/agents/.config/opencode/config.json
+++ b/Configs/agents/.config/opencode/config.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://opencode.ai/config.json",
 	"permissions": {
 		"files": "allow",
 		"commands": "allow",
@@ -10,10 +11,7 @@
 		"/Users/ifiokjr/Developer",
 		"/tmp"
 	],
-	"model": {
-		"default_provider": "ollama-cloud",
-		"default_model": "kimi-k2.5"
-	},
+	"model": "ollama-cloud/kimi-k2.5",
 	"ui": {
 		"confirm_destructive": false,
 		"confirm_tool_usage": false


### PR DESCRIPTION
opencode rejected the config at startup: `model` must be a string (`"provider/model"`), not an object. The invalid `{"default_provider": "ollama-cloud", "default_model": "kimi-k2.5"}` shape made opencode fail validation and auto-rewrite the file, silently dropping the model preference.

## Implementation

- **`Configs/agents/.config/opencode/config.json`** — replaced the invalid `model` object with `"model": "ollama-cloud/kimi-k2.5"` (verified as a valid provider/model via `opencode models`), and kept the `$schema` line opencode added.
- Verified `opencode models` runs cleanly with the fixed config.

_Created on behalf of Ifiok Jr. ([@ifiokjr](https://github.com/ifiokjr)) by pi using deepseek-v4-flash:0731 at high thinking._